### PR TITLE
#761 Data views fix

### DIFF
--- a/src/components/data_display/routes.ts
+++ b/src/components/data_display/routes.ts
@@ -40,7 +40,7 @@ const routeDataViewTable = async (request: any, reply: any) => {
   const orderBy = query?.orderBy ?? 'id'
   const ascending = query?.ascending ? query?.ascending === 'true' : true
 
-  const { columnDefinitionMasterList, fieldNames, gqlFilters, title, code } =
+  const { matchingTableName, columnDefinitionMasterList, fieldNames, gqlFilters, title, code } =
     await buildAllColumnDefinitions({
       permissionNames,
       tableName,
@@ -51,7 +51,7 @@ const routeDataViewTable = async (request: any, reply: any) => {
 
   // GraphQL query -- get ALL fields (passing JWT), with pagination
   const { fetchedRecords, totalCount, error } = await queryDataTable(
-    tableName,
+    matchingTableName,
     fieldNames,
     gqlFilters,
     first,
@@ -81,6 +81,7 @@ const routeDataViewDetail = async (request: any, reply: any) => {
   const { userId, orgId, permissionNames } = await getPermissionNamesFromJWT(request)
 
   const {
+    matchingTableName,
     columnDefinitionMasterList,
     title,
     fieldNames,
@@ -91,7 +92,7 @@ const routeDataViewDetail = async (request: any, reply: any) => {
 
   // GraphQL query -- get ALL fields (passing JWT), with pagination
   const fetchedRecord = await queryDataTableSingleItem(
-    tableName,
+    matchingTableName,
     fieldNames,
     gqlFilters,
     recordId,
@@ -102,7 +103,7 @@ const routeDataViewDetail = async (request: any, reply: any) => {
 
   // GraphQL query to get linked applications -- this one with Admin JWT!
   const linkedApplications = showLinkedApplications
-    ? await queryLinkedApplications(recordId, tableName)
+    ? await queryLinkedApplications(recordId, matchingTableName)
     : undefined
 
   const response = await constructDetailsResponse(

--- a/src/components/data_display/types.ts
+++ b/src/components/data_display/types.ts
@@ -55,6 +55,7 @@ export interface ColumnDefinition {
 export type ColumnDefinitionMasterList = ColumnDefinition[]
 
 export interface ColumnDetailOutput {
+  matchingTableName: string
   title: string
   code: string
   columnDefinitionMasterList: ColumnDefinitionMasterList

--- a/src/components/utilityFunctions.ts
+++ b/src/components/utilityFunctions.ts
@@ -84,3 +84,5 @@ export const filterObject = (
   const filtered = Object.entries(inputObj).filter(([_, value]) => filterFunction(value))
   return Object.fromEntries(filtered)
 }
+
+export const capitaliseFirstLetter = (str: string) => str[0].toUpperCase() + str.slice(1)


### PR DESCRIPTION
Fix #761

Data view entries do **NOT** require the prefix in the table name column -- it will automatically be added (and we check for the non-prefix version as well), but if you do add the prefix it should still work.

You'll need to rename the application join table to match then name of the entity table it's linked to (e.g. data_table_product -> data_table_product_application_join) AND update the column name to have the prefix included (i.e. product_id -> data_table_product_id)