### PR TITLE
#768 Dummy action for Alias and alias functionality

### DIFF
--- a/plugins/action_alias/plugin.json
+++ b/plugins/action_alias/plugin.json
@@ -1,0 +1,24 @@
+{
+  "type": "action_plugin",
+  "code": "alias",
+  "name": "Alias Action",
+  "description": "Dummy plugin to facilitate aliasing of template actions",
+  "required_parameters": ["code"],
+  "optional_parameters": ["condition", "...anyPluginFields"],
+  "output_properties": [],
+  "info": {
+    "author": {
+      "name": "The mSupply Foundation",
+      "url": "http://msupply.foundation"
+    },
+    "keywords": ["action", "update"],
+    "logos": {
+      "small": "",
+      "large": ""
+    },
+    "links": [],
+    "screenshots": [],
+    "version": "1.0.0",
+    "updated": "2022-06-30"
+  }
+}

--- a/plugins/action_alias/src/index.ts
+++ b/plugins/action_alias/src/index.ts
@@ -1,0 +1,4 @@
+// Dummy file so the system thinks this plugin exists and template_elements can
+// be created for it. But all the alias logic is handled internally as part of
+// the "processTrigger" function
+export {}

--- a/src/components/actions/helpers.ts
+++ b/src/components/actions/helpers.ts
@@ -1,0 +1,30 @@
+import { ActionInTemplate } from '../../types'
+import DBConnect from '../databaseConnect'
+
+export const swapOutAliasedActions = async (templateId: number, action: ActionInTemplate) => {
+  // Fetch aliased action from database
+  const {
+    condition,
+    parameter_queries: { code, condition: altCondition, ...overrideParams },
+  } = action
+  if (!code) throw new Error('Missing code in aliased action')
+
+  const aliasedAction = await DBConnect.getSingleTemplateAction(templateId, code)
+
+  if (!aliasedAction) throw new Error('No Action matching alias')
+
+  // Override condition if specified
+  // It would make most sense for actual condition field to be the one we look
+  // at for overriding the aliased action's condition, but because this has
+  // default "true" and can never be null, then we'd always get "true" as the
+  // condition. So we only consider the condition field if it's something other
+  // than "true". And if we actually *want* it to be "true", then we can
+  // override it further by specifying a "condition" field in parameters
+  if (condition !== true) aliasedAction.condition = condition
+  if (altCondition !== undefined) aliasedAction.condition = altCondition
+
+  // Override parameters
+  aliasedAction.parameter_queries = { ...aliasedAction.parameter_queries, ...overrideParams }
+
+  return aliasedAction
+}

--- a/src/components/databaseConnect.ts
+++ b/src/components/databaseConnect.ts
@@ -44,6 +44,8 @@ class DBConnect {
 
   public getActionsByTemplateId = PostgresDB.getActionsByTemplateId
 
+  public getSingleTemplateAction = PostgresDB.getSingleTemplateAction
+
   public updateActionPlugin = PostgresDB.updateActionPlugin
 
   public updateTriggerQueueStatus = PostgresDB.updateTriggerQueueStatus

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -419,6 +419,25 @@ class PostgresDB {
     }
   }
 
+  public getSingleTemplateAction = async (
+    templateId: number,
+    code: string
+  ): Promise<ActionInTemplate> => {
+    const text = `
+      SELECT action_plugin.code, action_plugin.path, action_plugin.name, trigger, template_action.event_code AS event_code, sequence, condition, parameter_queries 
+      FROM template 
+      JOIN template_action ON template.id = template_action.template_id 
+      JOIN action_plugin ON template_action.action_code = action_plugin.code 
+      WHERE template_id = $1 AND template_action.code = $2
+    `
+    try {
+      const result = await this.query({ text, values: [templateId, code] })
+      return result.rows[0] as ActionInTemplate
+    } catch (err) {
+      throw err
+    }
+  }
+
   public updateActionPlugin = async (plugin: ActionPlugin): Promise<boolean> => {
     const setMapping = Object.keys(plugin).map((key, index) => `${key} = $${index + 1}`)
     const text = `UPDATE action_plugin SET ${setMapping.join(',')} WHERE code = $${


### PR DESCRIPTION
Fix #768 

Implemented as described in [issue](#768)

To test: there is a snapshot in the templates repo: `/dev/snapshots/AliasActionTesting`

If you load this, you'll see there is two aliased actions in the "Aliased Actions" template, with the DEV_TEST trigger. One has a condition set as "true" (i.e. will always run), the other doesn't so will run as per the condition of the original action. 

Trigger them both with:
```
UPDATE application SET trigger = 'DEV_TEST' where id = 239;
```

The two "sendNotification" actions will be called via the aliases. One will execute, but *won't* send an email, as the `sendEmail` parameter has been over-ridden to `false` (You'll be able to see the notification it created in the "notification" table). The other won't execute due to "Condition not met".