### PR TITLE
#813 Fix broken docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,6 @@ WORKDIR /usr/src/conforma-web-app
 RUN cp .npmrc .npmrc_backup
 RUN echo "" >> .npmrc
 RUN --mount=type=secret,id=githubtoken,dst=/githubtoken echo "//npm.pkg.github.com/:_authToken=$(cat /githubtoken)" >> .npmrc
-RUN sed -i "s/dev/ ${SERVER_BRANCH}/g" src/config.ts 
 RUN yarn install
 RUN yarn build
 RUN rm .npmrc && mv .npmrc_backup .npmrc


### PR DESCRIPTION
This took a long time to track down -- thought it was a Typescript compilation problem, or something to do with the changes I made the webpack builder last week.

Turned out to just be a redundant line in the Dockerfile script:
```
RUN sed -i "s/dev/ ${SERVER_BRANCH}/g" src/config.ts
```

This line *used* to replace the string "dev" in "config.ts" with the version number from SERVER_BRANCH. But we haven't used this for a while, as we get the version number directly from package.json now. So this line was doing nothing -- until last week when I foolishly created config properties called `devServerRest` and `devServerGraphQL`, so now this line stripped out the string "dev" and replaced it with a branch name! No wonder the modified files didn't build. 🙄

Anyway, hopefully this fixes everything properly. I'll do a full build in the morning and check that it's all working properly. (Currently I've only tested enough to get past the bit that was breaking)