### PR TITLE
#1199F Optional reviewability schema update

### DIFF
--- a/database/buildSchema/16_template_element.sql
+++ b/database/buildSchema/16_template_element.sql
@@ -6,7 +6,11 @@ CREATE TYPE public.template_element_category AS ENUM (
 
 CREATE TYPE public.is_reviewable_status AS ENUM (
     'ALWAYS',
-    'NEVER'
+    'NEVER',
+    'OPTIONAL_IF_NO_RESPONSE'
+    -- TO-DO:
+    -- 'OPTIONAL_IF_RESPONSE',
+    -- 'OPTIONAL' (the above two combined)
 );
 
 -- FUNCTION to return template_code for current element/section

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -643,6 +643,16 @@ const migrateData = async () => {
     `)
   }
 
+  // v0.4.4
+  if (databaseVersionLessThan('0.4.4')) {
+    console.log(' - Add "Optional if no response" option to "is_reviewable"')
+
+    await DB.changeSchema(`
+      ALTER TYPE public.is_reviewable_status ADD VALUE IF NOT EXISTS
+      'OPTIONAL_IF_NO_RESPONSE' AFTER 'NEVER';
+    `)
+  }
+
   // Other version migrations continue here...
 
   // Finally, set the database version to the current version


### PR DESCRIPTION
Adds extra enum value for is_reviewable_status: `OPTIONAL_IF_NO_RESPONSE`

Required for front-end PR ?? (Coming soon)

@nmadruga The migration code will conflict with your PR, so we'll need to co-ordinate resolving that at some point.