### PR TITLE
Evaluator functions -- couple of date functions

### DIFF
--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -20,4 +20,8 @@ const getFormattedDate = (formatString: string, date?: string | Date) =>
     : DateTime.now()
   ).toFormat(formatString)
 
-export default { generateExpiry, getYear, getFormattedDate }
+// Returns JS Date object from ISO date string. Returns current timestamp if
+// no parameter supplied
+const getJSDate = (date?: string) => (date ? DateTime.fromISO(date).toJSDate() : new Date())
+
+export default { generateExpiry, getYear, getFormattedDate, getJSDate }

--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -24,4 +24,9 @@ const getFormattedDate = (formatString: string, date?: string | Date) =>
 // no parameter supplied
 const getJSDate = (date?: string) => (date ? DateTime.fromISO(date).toJSDate() : new Date())
 
-export default { generateExpiry, getYear, getFormattedDate, getJSDate }
+// Returns ISO date-time string from JS Date object. Returns current timestamp
+// if no parameter supplied
+const getISODate = (date?: Date) =>
+  date ? DateTime.fromJSDate(date).toISO() : DateTime.now().toISO()
+
+export default { generateExpiry, getYear, getFormattedDate, getJSDate, getISODate }


### PR DESCRIPTION
Couple of date functions which make it easier to get the current time. "modifyRecord" should be able to parse both JSDate and ISO string, but JSDate would be safer, so use that when possible.