### PR TITLE
#827 Fix for stray data in localisation (and prefs) folder

### DIFF
--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -27,6 +27,7 @@ import {
   PREFERENCES_FILE,
   SCHEMA_FILE_NAME,
   INFO_FILE_NAME,
+  PREFERENCES_FOLDER,
 } from '../../constants'
 
 const useSnapshot: SnapshotOperation = async ({
@@ -97,6 +98,7 @@ const useSnapshot: SnapshotOperation = async ({
     // Import localisations
     if (options?.includeLocalisation) {
       try {
+        execSync(`rm -rf ${LOCALISATION_FOLDER}/*`)
         execSync(`cp -r  '${snapshotFolder}/localisation/.' '${LOCALISATION_FOLDER}' `)
       } catch (e) {
         console.log("Couldn't import localisations")
@@ -106,6 +108,7 @@ const useSnapshot: SnapshotOperation = async ({
     // Import preferences
     if (options?.includePrefs) {
       try {
+        execSync(`rm -rf ${PREFERENCES_FOLDER}/*`)
         execSync(`cp '${snapshotFolder}/preferences.json' '${PREFERENCES_FILE}'`)
       } catch (e) {
         console.log("Couldn't import preferences")


### PR DESCRIPTION
Fix #827 

Finally worked out what's going on here! Every time I tried to replicate it, I couldn't -- and yet the annoying, nested "localisations" folder kept appearing inside the snapshot folder... *sometimes*.

![Screen Shot 2022-08-31 at 3 51 52 PM](https://user-images.githubusercontent.com/5456533/187589069-f97c6d0f-54c8-44a5-abd0-7055ebf6e02a.png)

Turns out, we weren't completely clearing out existing content in the "localisation" and "preferences" in our snapshot script.  And so one of you... 👀 must have had some crap left in your localisation folder from waaay back which was never getting deleted. And so every time _that particular person_ saved a snapshot, this crap came along with it. The reason why I couldn't reproduce it is that my localisations folder was clean...but someone else's wasn't. 🤨

Now that I understand what's going on -- it's a simple fix: just clear out the localisation and preferences folders when we load the snapshot.

We'll still need to clear the crap out of the current snapshot, but at least that'll be the last time (hopefully!!!)