### PR TITLE
#830 Return snapshot name to front-end

### DIFF
--- a/src/components/databaseConnect.ts
+++ b/src/components/databaseConnect.ts
@@ -156,6 +156,8 @@ class DBConnect {
 
   public getApplicationSections = PostgresDB.getApplicationSections
 
+  public getLatestSnapshotName = PostgresDB.getLatestSnapshotName
+
   public waitForDatabaseValue = PostgresDB.waitForDatabaseValue
 
   // GraphQL

--- a/src/components/permissions/routes.ts
+++ b/src/components/permissions/routes.ts
@@ -206,7 +206,8 @@ const routeGetPrefs = async (request: any, reply: any) => {
     readFileSync(path.join(getAppEntryPointDir(), '../preferences/preferences.json'), 'utf8')
   )
   const languageOptions = readLanguageOptions()
-  reply.send({ preferences: prefs.web, languageOptions })
+  const latestSnapshot = await databaseConnect.getLatestSnapshotName()
+  reply.send({ preferences: prefs.web, languageOptions, latestSnapshot })
 }
 
 // Unique name/email/organisation/other check

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -1123,6 +1123,22 @@ class PostgresDB {
     }
   }
 
+  public getLatestSnapshotName = async () => {
+    const text = `SELECT value
+    FROM system_info
+    WHERE timestamp =
+      (SELECT MAX(timestamp) FROM system_info
+      WHERE name='snapshot')
+     `
+    try {
+      const result = await this.query({ text })
+      return result.rows[0].value
+    } catch (err) {
+      console.log(err.message)
+      throw err
+    }
+  }
+
   public waitForDatabaseValue = async ({
     table,
     column,

--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -3,6 +3,7 @@ import fsSync from 'fs'
 import path from 'path'
 import { execSync } from 'child_process'
 import insertData from '../../../database/insertData'
+import DBConnect from '../../../src/components/databaseConnect'
 import updateRowPolicies from '../../../database/updateRowPolicies'
 import { SnapshotOperation, ExportAndImportOptions, ObjectRecord } from '../exportAndImport/types'
 import importFromJson from '../exportAndImport/importFromJson'
@@ -132,6 +133,14 @@ const useSnapshot: SnapshotOperation = async ({
 
     // To ensure generic thumbnails are not wiped out, even if server doesn't restart
     createDefaultDataFolders()
+
+    // Store snapshot name in database
+    const text = `INSERT INTO system_info (name, value)
+    VALUES('snapshot', $1)`
+    await DBConnect.query({
+      text,
+      values: [JSON.stringify(snapshotName)],
+    })
 
     return { success: true, message: `snapshot loaded ${snapshotName}` }
   } catch (e) {


### PR DESCRIPTION
Fix #830 

Use front-end: https://github.com/openmsupply/conforma-web-app/pull/1332

This will be pretty handy for reminding ourselves which snapshot we have loaded on various instances. When loading a snapshot, we save the snapshot name in the "system_info" table, then return this info with prefs. In the front-end it can be displayed in the Footer (to Admin only):

<img width="282" alt="Screen Shot 2022-09-02 at 12 24 43 AM" src="https://user-images.githubusercontent.com/5456533/187913094-195427f2-040a-4bf4-b255-ab1268d5bd72.png">
