### PR TITLE
#1302B Increase 'bodySizeLimit' for postgraphile

### DIFF
--- a/.postgraphilerc.js
+++ b/.postgraphilerc.js
@@ -16,5 +16,6 @@ module.exports = {
     graphileBuildOptions: {
       connectionFilterRelations: true,
     },
+    bodySizeLimit: '500kb',
   },
 }


### PR DESCRIPTION
Fix front-end https://github.com/openmsupply/conforma-web-app/issues/1302

Two-pronged fix for this one:

- increase the "bodySizeLimit" for Postgraphile POST request (to '500kb', default is '100kb') (in this PR) ([PG docs ref](https://github.com/openmsupply/conforma-web-app/issues/1302))
- don't submit response values in "application submit" mutations (front-end PR ??)