### PR TITLE
#845 Fix for template version bug

### DIFF
--- a/src/components/snapshots/triggerTables.ts
+++ b/src/components/snapshots/triggerTables.ts
@@ -22,7 +22,6 @@ export const triggerTables = [
   'application_response',
   'application_stage_history',
   'application_status_history',
-  'template',
   'review',
   'review_decision',
   'review_response',
@@ -32,3 +31,11 @@ export const triggerTables = [
   'permission_join',
   'file',
 ]
+
+/*
+The following tables have triggers, but *shouldn't* be disabled, as
+they're required for the snapshot import process:
+
+- template
+
+*/


### PR DESCRIPTION
Fix #845 

Just removed `template` table from the list of tables which get triggers disabled on snapshot load.

Please let me know if you can think of any others that might cause problems. (I don't think there are any other triggers that are required during snapshot load)