### PR TITLE
#849 (1) Disable triggers only for full database re-init

### DIFF
--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -1,5 +1,10 @@
-// Utility functions to extend capabilities of expression evaluator via the
-// "objectFunctions" operator
+/*
+Utility functions to extend capabilities of expression evaluator via the
+"objectFunctions" operator.
+
+Any changes done here should also be replicated in front-end
+"evaluatorFunctions.ts"so they can be simulated in the Template Builder.
+ */
 
 import { DateTime, Duration } from 'luxon'
 

--- a/src/components/snapshots/triggerTables.ts
+++ b/src/components/snapshots/triggerTables.ts
@@ -5,6 +5,8 @@ A list of tables whose triggers should be suppressed during snapshot data
 insert, so they don't create extraneous records in the activity_log, or other
 unwanted behaviours.
 
+Note: we don't disable these for template-only imports, as some of the triggers are actually required e.g. template version management trigger
+
 Get a list of all tables that have triggers with the following query:
 
 SELECT  event_object_table AS table_name ,trigger_name         
@@ -18,6 +20,7 @@ export const triggerTables = [
   'trigger_queue',
   'trigger_schedule',
   'verification',
+  'template',
   'application',
   'application_response',
   'application_stage_history',
@@ -31,11 +34,3 @@ export const triggerTables = [
   'permission_join',
   'file',
 ]
-
-/*
-The following tables have triggers, but *shouldn't* be disabled, as
-they're required for the snapshot import process:
-
-- template
-
-*/

--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -73,10 +73,14 @@ const useSnapshot: SnapshotOperation = async ({
       execSync(`rm -rf ${FILES_FOLDER}/*`)
     }
 
-    // Prevent triggers from running while we insert data
-    triggerTables.forEach((table) => {
-      execSync(`psql -U postgres -d tmf_app_manager -c "ALTER TABLE ${table} DISABLE TRIGGER ALL"`)
-    })
+    // Prevent triggers from running while we insert data, but only for full re-init
+    if (options.shouldReInitialise) {
+      triggerTables.forEach((table) => {
+        execSync(
+          `psql -U postgres -d tmf_app_manager -c "ALTER TABLE ${table} DISABLE TRIGGER ALL"`
+        )
+      })
+    }
 
     // Pause to allow postgraphile "watch" to detect changed schema
     delay(2500)

--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -141,13 +141,15 @@ const useSnapshot: SnapshotOperation = async ({
     // To ensure generic thumbnails are not wiped out, even if server doesn't restart
     createDefaultDataFolders()
 
-    // Store snapshot name in database
-    const text = `INSERT INTO system_info (name, value)
-    VALUES('snapshot', $1)`
-    await DBConnect.query({
-      text,
-      values: [JSON.stringify(snapshotName)],
-    })
+    // Store snapshot name in database (for full imports only)
+    if (options.shouldReInitialise) {
+      const text = `INSERT INTO system_info (name, value)
+      VALUES('snapshot', $1)`
+      await DBConnect.query({
+        text,
+        values: [JSON.stringify(snapshotName)],
+      })
+    }
 
     return { success: true, message: `snapshot loaded ${snapshotName}` }
   } catch (e) {


### PR DESCRIPTION
Fix #849 Part 1:

> 1. change the "disable trigger" script that I altered the other day to _not_ disable when doing a template-only import (and restore "template" to the list of triggerTables)

Part 2 done in front-end [#1344](https://github.com/openmsupply/conforma-web-app/pull/1344)