### PR TITLE
#856 revokePermission changes

### DIFF
--- a/documentation/List-of-Action-plugins.md
+++ b/documentation/List-of-Action-plugins.md
@@ -8,10 +8,8 @@
   - [Increment Stage](#increment-stage)
   - [Change Status](#change-status)
   - [Modify Record](#modify-record)
-    - [How the record is built](#how-the-record-is-built)
   - [Modify Multiple Records](#modify-multiple-records)
   - [Generate Text String](#generate-text-string)
-    - [Parameters summary](#parameters-summary)
   - [Join User to Organsation](#join-user-to-organsation)
   - [Grant Permissions](#grant-permissions)
   - [Revoke Permissions](#revoke-permissions)
@@ -27,14 +25,6 @@
   - [Clean Up Files](#clean-up-files)
   - [Aliasing existing template actions](#aliasing-existing-template-actions)
 - [Core Actions](#core-actions)
-    - [On Application Create:](#on-application-create)
-    - [On Application Submit](#on-application-submit)
-    - [On Application Restart (i.e. after "Changes Requested"):](#on-application-restart-ie-after-changes-requested)
-    - [On Review Self-Assign:](#on-review-self-assign)
-    - [On Review Assign (by other)](#on-review-assign-by-other)
-    - [On Review Create](#on-review-create)
-    - [On Review Submit:](#on-review-submit)
-    - [On Review Restart: (i.e. review making changes based on higher level requests)](#on-review-restart-ie-review-making-changes-based-on-higher-level-requests)
 
 * [Core Actions](#core-actions)
 
@@ -440,6 +430,8 @@ Revokes permissions from to user/org -- i.e. sets the `is_active` field to `fals
 | `orgName` or `orgId`                     |                                                                                      |
 | `permissionNames`\* [Array of names]     |                                                                                      |
 | `isRemovingPermission` (default: `true`) |                                                                                      |
+
+`revokePermissions` works differently to `grantPermissions`, in that you *can* omit the user or the org. In that case, it is treated as "apply to ALL". So if you only provide an `orgId`, it'll remove any permission for that organisation, regardless of which user (or `null`) is linked with it. However, if you explicitly set `null` for one of the values, it'll only match `null`.
 
 The `isRemovingPermission` parameter specifies whether or not the `permission_join` record should be _deleted_ (the default behaviour) or just set to inactive (which would mean the user can still _view_ their applications but not create new ones, or submit existing). _**NOTE**: This functionality not actually implemented yet in policies/front-end, so only full removal should be used currently -- TO-DO_
 

--- a/plugins/action_revoke_permissions/src/databaseMethods.ts
+++ b/plugins/action_revoke_permissions/src/databaseMethods.ts
@@ -1,6 +1,7 @@
 const databaseMethods = (DBConnect: any) => ({
   revokePermissionFromUser: async (
     userId: number,
+    orgId: null | undefined,
     permissionIds: number[],
     isRemovingPermissions: boolean = true
   ) => {
@@ -12,7 +13,7 @@ const databaseMethods = (DBConnect: any) => ({
       } 
       WHERE user_id = $1
         AND permission_name_id = ANY($2)
-        AND organisation_id IS NULL
+        ${orgId === null ? 'AND organisation_id IS NULL' : ''}
       RETURNING
         id as "permissionJoinId",
         permission_name_id as "permissionNameId",
@@ -55,6 +56,7 @@ const databaseMethods = (DBConnect: any) => ({
   },
   revokePermissionFromOrg: async (
     orgId: number,
+    userId: null | undefined,
     permissionIds: number[],
     isRemovingPermissions: boolean = true
   ) => {
@@ -66,7 +68,7 @@ const databaseMethods = (DBConnect: any) => ({
       } 
       WHERE organisation_id = $1
         AND permission_name_id = ANY($2)
-        AND user_id IS NULL
+        ${userId === null ? 'AND user_id IS NULL' : ''}
       RETURNING
         id as "permissionJoinId",
         permission_name_id as "permissionNameId",

--- a/plugins/action_revoke_permissions/src/revokePermissions.ts
+++ b/plugins/action_revoke_permissions/src/revokePermissions.ts
@@ -15,29 +15,15 @@ const revokePermissions = async ({ applicationData, parameters, DBConnect }: Act
         ? null
         : parameters?.userId ?? (await dbCommon.getUserIdFromUsername(username))
 
-    if (userId === undefined)
-      return {
-        status: ActionQueueStatus.Fail,
-        error_log: 'Invalid or missing userId or username',
-        output: {},
-      }
-
     const orgId =
       parameters?.orgId === null
         ? null
         : parameters?.orgId ?? (await dbCommon.getOrgIdFromOrgname(orgName))
 
-    if (orgId === undefined)
-      return {
-        status: ActionQueueStatus.Fail,
-        error_log: 'Invalid or missing orgId or orgName',
-        output: {},
-      }
-
     if (!userId && !orgId)
       return {
         status: ActionQueueStatus.Fail,
-        error_log: 'user and org cannot both be null',
+        error_log: 'user and org cannot both be null or undefined',
         output: {},
       }
 
@@ -59,9 +45,10 @@ const revokePermissions = async ({ applicationData, parameters, DBConnect }: Act
           await db.revokePermissionFromUserOrg(userId, orgId, permissionIds, isRemovingPermission)
         : userId
         ? // User only, no org
-          await db.revokePermissionFromUser(userId, permissionIds, isRemovingPermission)
+          await db.revokePermissionFromUser(userId, orgId, permissionIds, isRemovingPermission)
         : // Org only, no user
-          orgId && (await db.revokePermissionFromOrg(orgId, permissionIds, isRemovingPermission))
+          orgId &&
+          (await db.revokePermissionFromOrg(orgId, userId, permissionIds, isRemovingPermission))
 
     console.log('Revoked permissions:')
     console.log(


### PR DESCRIPTION
Fix #856 

Changes action so that "undefined" (i.e. not provided) will match ALL. `null` will still only match explicit `null` values.

This is so we can revoke ALL permissions related to a company, no matter which user(s) they are linked to.