### PR TITLE
#31T - Adding new optional locale to getFormattedDate function

### DIFF
--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -10,15 +10,26 @@ const generateExpiry = (duration: Duration) => DateTime.now().plus(duration).toJ
 const getYear = (type?: 'short'): string =>
   type === 'short' ? String(new Date().getFullYear()).slice(2) : String(new Date().getFullYear())
 
+type FormatDate =
+  | string
+  | {
+      format: string
+      locale: string
+    }
+
 // Returns ISO date string or JS Date as formatted Date (Luxon). Returns current
 // date if date not supplied
-const getFormattedDate = (formatString: string, date?: string | Date) =>
-  (date
+const getFormattedDate = (formatString: FormatDate, date?: string | Date) => {
+  const tempDate = date
     ? typeof date === 'string'
       ? DateTime.fromISO(date)
       : DateTime.fromJSDate(date)
     : DateTime.now()
-  ).toFormat(formatString)
+
+  if (typeof formatString === 'string') return tempDate.toFormat(formatString)
+  const { format, locale } = formatString
+  return tempDate.setLocale(locale).toFormat(format)
+}
 
 // Returns JS Date object from ISO date string. Returns current timestamp if
 // no parameter supplied

--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -16,18 +16,19 @@ type FormatDate =
       format: string
       locale?: string
     }
+
 // Returns ISO date string or JS Date as formatted Date (Luxon). Returns current
 // date if date not supplied
-const getFormattedDate = (formatString: FormatDate, date?: string | Date) => {
-  const tempDate = date
-    ? typeof date === 'string'
-      ? DateTime.fromISO(date)
-      : DateTime.fromJSDate(date)
+const getFormattedDate = (formatString: FormatDate, inputDate?: string | Date) => {
+  const date = inputDate
+    ? typeof inputDate === 'string'
+      ? DateTime.fromISO(inputDate)
+      : DateTime.fromJSDate(inputDate)
     : DateTime.now()
 
-  if (typeof formatString === 'string') return tempDate.toFormat(formatString)
+  if (typeof formatString === 'string') return date.toFormat(formatString)
   const { format, locale } = formatString
-  return tempDate.setLocale(locale).toFormat(format)
+  return locale ? date.setLocale(locale).toFormat(format) : date.toFormat(format)
 }
 
 // Returns JS Date object from ISO date string. Returns current timestamp if

--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -14,9 +14,8 @@ type FormatDate =
   | string
   | {
       format: string
-      locale: string
+      locale?: string
     }
-
 // Returns ISO date string or JS Date as formatted Date (Luxon). Returns current
 // date if date not supplied
 const getFormattedDate = (formatString: FormatDate, date?: string | Date) => {

--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -28,7 +28,7 @@ const getFormattedDate = (formatString: FormatDate, inputDate?: string | Date) =
 
   if (typeof formatString === 'string') return date.toFormat(formatString)
   const { format, locale } = formatString
-  return locale ? date.setLocale(locale).toFormat(format) : date.toFormat(format)
+  return date.toFormat(format, { locale })
 }
 
 // Returns JS Date object from ISO date string. Returns current timestamp if


### PR DESCRIPTION
Added in Conforma-templates issues list since was made for country-specific requirement: 
Fixes https://github.com/openmsupply/conforma-templates/issues/31

Basically added new option on `getFormmatedDate` same as in Front-end (where explained in details) [PR-Front-end](https://github.com/openmsupply/conforma-web-app/pull/1349)