### PR TITLE
Update docker entrypoint to append log on restart

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -28,7 +28,7 @@ yarn postgraphile \
    --disable-query-log \
    -r graphile_user \
    -q '/postgraphile/graphql' \
-   -i '/postgraphile/graphiql' | tee /var/log/conforma/graphile.log &
+   -i '/postgraphile/graphiql' | tee -a /var/log/conforma/graphile.log &
 sleep 3
 
 echo '---'
@@ -36,7 +36,7 @@ echo '---'
 echo '--- STARTING SERVER'
 echo '---'
 echo '---'
-NODE_ENV=production node ./build/src/server.js | tee /var/log/conforma/server.log &
+NODE_ENV=production node ./build/src/server.js | tee -a /var/log/conforma/server.log &
 
 echo '---'
 echo '---'


### PR DESCRIPTION
When dockerised server is restarted, logs are disappearing. Looks like `tee` command needs to have `-a` for appending rather then overwriting log file. 
/var/log/conforma volume should also be added, this is for log to persist after upgrades (volume should still persist after docker container restarts, unless container is removed)