### PR TITLE
#932 fix crashing on history panel

### DIFF
--- a/database/buildSchema/43_views_functions_triggers.sql
+++ b/database/buildSchema/43_views_functions_triggers.sql
@@ -277,12 +277,15 @@ IMMUTABLE;
 -- Add columns (and index) to template_element table that use the above 2
 -- functions
 ALTER TABLE public.template_element
+    DROP COLUMN IF EXISTS template_code,
     ADD COLUMN IF NOT EXISTS template_code varchar GENERATED ALWAYS AS (public.get_template_code (section_id)) STORED;
 
 ALTER TABLE public.template_element
+    DROP COLUMN IF EXISTS template_version,
     ADD COLUMN IF NOT EXISTS template_version integer GENERATED ALWAYS AS (public.get_template_version (section_id)) STORED;
 
-CREATE UNIQUE INDEX IF NOT EXISTS template_element_template_code_code_template_version_idx ON public.template_element (template_code, code, template_version);
+ALTER TABLE public.template_element
+    ADD UNIQUE (template_code, code, template_version);
 
 -- APPLICATION
 --FUNCTION to update `is_active` to false


### PR DESCRIPTION
Fix #932 

This also fixes the problem @nmadruga was having loading my snapshot for https://github.com/openmsupply/conforma-web-app/pull/1386!

Turns out that (somehow) the auto-generated values for the "template_code" and "template_version" on the "template_element" table were missing (had `null` values), and also the "unique" constraint for `template_code, code, template_version` was not being re-generated, and this constraint was required as part of the `templateElementByTemplateCodeAndCodeAndTemplateVersion` query the HistoryPanel uses

This change just drops and recreates the generated columns, and ensures the uniqueness constraint is re-added every time.

In order to test -- download `angola_2022_09_27_1616_server` from the Angola SERVER (50000), load it, and go to the review shown in Jess's screen recording: http://localhost:3000/application/AIM-2022-0084/review/21?activeSections=all (You need to be logged in as 'tecnico2' to see it) 