### PR TITLE
Fix for missing generated column data

### DIFF
--- a/database/buildSchema/27_review_assignment.sql
+++ b/database/buildSchema/27_review_assignment.sql
@@ -1,19 +1,5 @@
 -- review assignment
--- FUNCTION to auto-add template_id to review_assignment
-CREATE OR REPLACE FUNCTION public.review_assignment_template_id (application_id int)
-    RETURNS int
-    AS $$
-    SELECT
-        template_id
-    FROM
-        application
-    WHERE
-        id = $1;
-
-$$
-LANGUAGE SQL
-IMMUTABLE;
-
+--
 -- ENUM
 CREATE TYPE public.review_assignment_status AS ENUM (
     'AVAILABLE',
@@ -30,7 +16,7 @@ CREATE TABLE public.review_assignment (
     time_stage_created timestamptz,
     status public.review_assignment_status NOT NULL,
     application_id integer REFERENCES public.application (id) ON DELETE CASCADE NOT NULL,
-    template_id integer GENERATED ALWAYS AS (public.review_assignment_template_id (application_id)) STORED REFERENCES public.template (id) ON DELETE CASCADE,
+    -- template_id -- added later after generating function created
     allowed_sections varchar[] DEFAULT NULL,
     assigned_sections varchar[] DEFAULT ARRAY[] ::varchar[] NOT NULL,
     TRIGGER public.trigger,

--- a/database/buildSchema/43_views_functions_triggers.sql
+++ b/database/buildSchema/43_views_functions_triggers.sql
@@ -789,6 +789,14 @@ IMMUTABLE;
 
 -- Add columns to "review" now that these functions are defined:
 ALTER TABLE public.review
+    DROP COLUMN IF EXISTS application_id CASCADE,
+    DROP COLUMN IF EXISTS reviewer_id CASCADE,
+    DROP COLUMN IF EXISTS level_number CASCADE,
+    DROP COLUMN IF EXISTS stage_number CASCADE,
+    DROP COLUMN IF EXISTS time_stage_created CASCADE,
+    DROP COLUMN IF EXISTS is_last_level CASCADE,
+    DROP COLUMN IF EXISTS is_last_stage CASCADE,
+    DROP COLUMN IF EXISTS is_final_decision CASCADE,
     ADD COLUMN IF NOT EXISTS application_id integer GENERATED ALWAYS AS (public.review_application_id (review_assignment_id)) STORED REFERENCES public.application (id) ON DELETE CASCADE,
     ADD COLUMN IF NOT EXISTS reviewer_id integer GENERATED ALWAYS AS (public.review_reviewer_id (review_assignment_id)) STORED REFERENCES public.user (id) ON DELETE CASCADE,
     ADD COLUMN IF NOT EXISTS level_number integer GENERATED ALWAYS AS (public.review_level (review_assignment_id)) STORED,


### PR DESCRIPTION
Okay, so this fixes the problem, but I'm still somewhat mystified as to why the "review" and "template_element" generated columns need to be recreated like this but other ones don't (like the one in "review_assignment", and "application_status_history") -- they seem to work exactly the same way.