### PR TITLE
#1412B Lookup table Dataview display

### DIFF
--- a/database/buildSchema/38_data_view.sql
+++ b/database/buildSchema/38_data_view.sql
@@ -42,6 +42,7 @@ CREATE TABLE data_table (
     table_name varchar NOT NULL UNIQUE,
     display_name varchar,
     field_map jsonb,
-    is_lookup_table boolean DEFAULT FALSE
+    is_lookup_table boolean DEFAULT FALSE,
+    data_view_code varchar
 );
 

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -578,6 +578,13 @@ const migrateData = async () => {
     CREATE EXTENSION IF NOT EXISTS citext;
     ALTER TABLE public.user ALTER COLUMN username TYPE citext;
     `)
+
+    console.log(' - Add column to data_table to link data views to lookup tables')
+
+    await DB.changeSchema(`
+    ALTER TABLE data_table
+    ADD COLUMN data_view_code varchar;
+    `)
   }
   // Other version migrations continue here...
 

--- a/src/components/data_display/routes.ts
+++ b/src/components/data_display/routes.ts
@@ -18,6 +18,9 @@ import { ColumnDefinition, LinkedApplication, DataViewsResponse } from './types'
 import { DataView } from '../../generated/graphql'
 import config from '../../config'
 
+// CONSTANTS
+const LOOKUP_TABLE_PERMISSION_NAME = 'lookupTables'
+
 const routeDataViews = async (request: any, reply: any) => {
   const { permissionNames } = await getPermissionNamesFromJWT(request)
   const dataViews = await DBConnect.getAllowedDataViews(permissionNames)
@@ -37,6 +40,7 @@ const routeDataViewTable = async (request: any, reply: any) => {
   const authHeaders = request?.headers?.authorization
   const dataViewCode = camelCase(request.params.dataViewCode)
   const { userId, orgId, permissionNames } = await getPermissionNamesFromJWT(request)
+  if (request.auth.isAdmin) permissionNames.push(LOOKUP_TABLE_PERMISSION_NAME)
   const query = objectKeysToCamelCase(request.query)
   const filter = request.body ?? {}
 
@@ -97,6 +101,7 @@ const routeDataViewDetail = async (request: any, reply: any) => {
   const dataViewCode = camelCase(request.params.dataViewCode)
   const recordId = Number(request.params.id)
   const { userId, orgId, permissionNames } = await getPermissionNamesFromJWT(request)
+  if (request.auth.isAdmin) permissionNames.push(LOOKUP_TABLE_PERMISSION_NAME)
 
   const {
     tableName,
@@ -153,6 +158,7 @@ const routeDataViewFilterList = async (request: any, reply: any) => {
     includeNull,
   } = request.body ?? {}
   const { userId, orgId, permissionNames } = await getPermissionNamesFromJWT(request)
+  if (request.auth.isAdmin) permissionNames.push(LOOKUP_TABLE_PERMISSION_NAME)
 
   const dataViews = (await DBConnect.getAllowedDataViews(permissionNames, dataViewCode))
     .map((dataView) => objectKeysToCamelCase(dataView))

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -7402,6 +7402,7 @@ export type DataTable = Node & {
   displayName?: Maybe<Scalars['String']>;
   fieldMap?: Maybe<Scalars['JSON']>;
   isLookupTable?: Maybe<Scalars['Boolean']>;
+  dataViewCode?: Maybe<Scalars['String']>;
 };
 
 export type DataTableActiveIngredient = Node & {
@@ -7977,6 +7978,8 @@ export type DataTableCondition = {
   fieldMap?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `isLookupTable` field. */
   isLookupTable?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `dataViewCode` field. */
+  dataViewCode?: Maybe<Scalars['String']>;
 };
 
 export type DataTableContainer = Node & {
@@ -8279,6 +8282,8 @@ export type DataTableFilter = {
   fieldMap?: Maybe<JsonFilter>;
   /** Filter by the object’s `isLookupTable` field. */
   isLookupTable?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `dataViewCode` field. */
+  dataViewCode?: Maybe<StringFilter>;
   /** Checks for all expressions in this list. */
   and?: Maybe<Array<DataTableFilter>>;
   /** Checks for any expressions in this list. */
@@ -8522,6 +8527,7 @@ export type DataTableInput = {
   displayName?: Maybe<Scalars['String']>;
   fieldMap?: Maybe<Scalars['JSON']>;
   isLookupTable?: Maybe<Scalars['Boolean']>;
+  dataViewCode?: Maybe<Scalars['String']>;
 };
 
 export type DataTableListOfSra = Node & {
@@ -8705,6 +8711,7 @@ export type DataTablePatch = {
   displayName?: Maybe<Scalars['String']>;
   fieldMap?: Maybe<Scalars['JSON']>;
   isLookupTable?: Maybe<Scalars['Boolean']>;
+  dataViewCode?: Maybe<Scalars['String']>;
 };
 
 export type DataTableProcessingStep = Node & {
@@ -9704,6 +9711,8 @@ export enum DataTablesOrderBy {
   FieldMapDesc = 'FIELD_MAP_DESC',
   IsLookupTableAsc = 'IS_LOOKUP_TABLE_ASC',
   IsLookupTableDesc = 'IS_LOOKUP_TABLE_DESC',
+  DataViewCodeAsc = 'DATA_VIEW_CODE_ASC',
+  DataViewCodeDesc = 'DATA_VIEW_CODE_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -46079,6 +46088,7 @@ export type DataTableResolvers<ContextType = any, ParentType extends ResolversPa
   displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   fieldMap?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   isLookupTable?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  dataViewCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 


### PR DESCRIPTION
Back-end tweaks required for front-end issue: https://github.com/openmsupply/conforma-web-app/issues/1412

Adds another column to "data_table" to connect a "data_view" definition to a lookup table.

Also handles the "special" permission names "lookupTables" by inserting data views matching it into the list of "allowed" data views if the auth token contains `isAdmin` (which is what is required for viewing lookup tables, currently)