### PR TITLE
#70T-Fix-trigger-issue-after-unassignment

### DIFF
--- a/plugins/action_update_review_assignments_status/src/databaseMethods.ts
+++ b/plugins/action_update_review_assignments_status/src/databaseMethods.ts
@@ -1,3 +1,5 @@
+import { ReviewAssignment } from '../../../src/generated/graphql'
+
 const databaseMethods = (DBConnect: any) => ({
   getReviewAssignmentById: async (reviewAssignmentId: number) => {
     const text = `
@@ -21,9 +23,12 @@ const databaseMethods = (DBConnect: any) => ({
     stageNumber: number,
     reviewLevel: number,
     isSelfAssignable: boolean
-  ) => {
+  ): Promise<ReviewAssignment[]> => {
     const text = `
-    SELECT * FROM review_assignment
+    SELECT 
+      id,
+      assigned_sections as "assignedSections"
+    FROM review_assignment
     WHERE application_id = $2
     AND stage_number = $3
     AND level_number = $4
@@ -41,7 +46,7 @@ const databaseMethods = (DBConnect: any) => ({
       throw err
     }
   },
-  updateReviewAssignments: async (reviewAssignments: any) => {
+  updateReviewAssignments: async (reviewAssignments: { id: number; isLocked: boolean }[]) => {
     const reviewAssignmentUpdateResults = []
     for (const reviewAssignment of reviewAssignments) {
       const { id, isLocked } = reviewAssignment

--- a/plugins/action_update_review_assignments_status/src/updateReviewAssignmentsStatus.ts
+++ b/plugins/action_update_review_assignments_status/src/updateReviewAssignmentsStatus.ts
@@ -14,7 +14,7 @@ async function updateReviewAssignmentsStatus({
     const trigger = parameters?.trigger ?? applicationData?.action_payload?.trigger_payload?.trigger
     const { reviewAssignmentId } = parameters
 
-    let assignments: ReviewAssignment[] = []
+    let assignments: { id: number; isLocked: boolean }[] = []
     // NB: reviewAssignmentId comes from record_id on TriggerPayload when
     // triggered from review_assignment table
     const {
@@ -33,7 +33,7 @@ async function updateReviewAssignmentsStatus({
         isSelfAssignable
       )
 
-      return otherSelfAssignments.map(({ id, assignedSections }: ReviewAssignment) => ({
+      return otherSelfAssignments.map(({ id, assignedSections }) => ({
         id,
         isLocked: isLocked || assignedSections.length > 0,
       }))


### PR DESCRIPTION
Fixes https://github.com/openmsupply/conforma-templates/issues/70

Try checking using current snapshot loaded on demo instance 50004. Or use the latest on Fiji shared snapshot 

Problem was due to difference on returned (by `getMatchingReviewAssignments` Pg function) of snake_case and camelCase (expected). So now the only properties used are returned and converted to camelCase.

I still noticed that after Unassigning the page doesn't reload - so planning to add this fix to Front-end PR https://github.com/openmsupply/conforma-web-app/pull/1409