### PR TITLE
#66T Remove port requirement from single-instance servers

### DIFF
--- a/docker/demo_server/nginx_config_single/default
+++ b/docker/demo_server/nginx_config_single/default
@@ -3,14 +3,14 @@
 server {
     gzip_types text/plain application/xml text/css application/javascript;
 
-    listen [::]:50000 ssl ipv6only=on; # managed by Certbot
-    listen 50000 ssl; # managed by Certbot
+    listen [::]:443 ssl ipv6only=on; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
     ssl_certificate /etc/letsencrypt/live/<host-domain>/fullchain.pem; # managed by Certbot
     ssl_certificate_key /etc/letsencrypt/live/<host-domain>/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
-    error_page 497 301 =307 https://<host-domain>:50000$request_uri;
+    error_page 497 301 =307 https://<host-domain>$request_uri;
 
     location / {
         proxy_pass http://127.0.0.1:8000/;


### PR DESCRIPTION
Fix #66T

Have already implemented this on Fiji server: https://fiji.conforma.nz

Just changing it here for our default single-instance setup for future installations.