### PR TITLE
#953 Fix to only show action SELF_ASSIGN while there are available_sections to be assigned

### DIFF
--- a/database/buildSchema/43_views_functions_triggers.sql
+++ b/database/buildSchema/43_views_functions_triggers.sql
@@ -1397,6 +1397,8 @@ STABLE;
 
 -- REVIEWER_ACTION_LIST
 -- Aggregated VIEW method of reviewer action to each application on application list page
+DROP FUNCTION IF EXISTS review_list (integer, integer);
+
 DROP FUNCTION IF EXISTS review_list (integer, integer, public.application_status);
 
 CREATE OR REPLACE FUNCTION review_list (stageid int, reviewerid int, appstatus public.application_status)

--- a/database/buildSchema/43_views_functions_triggers.sql
+++ b/database/buildSchema/43_views_functions_triggers.sql
@@ -1397,6 +1397,8 @@ STABLE;
 
 -- REVIEWER_ACTION_LIST
 -- Aggregated VIEW method of reviewer action to each application on application list page
+DROP FUNCTION IF EXISTS review_list (integer, integer, public.application_status);
+
 CREATE OR REPLACE FUNCTION review_list (stageid int, reviewerid int, appstatus public.application_status)
     RETURNS TABLE (
         application_id int,
@@ -1422,8 +1424,8 @@ CREATE OR REPLACE FUNCTION review_list (stageid int, reviewerid int, appstatus p
             'START_REVIEW'
         WHEN COUNT(*) FILTER (WHERE review_assignment.status = 'AVAILABLE'
             AND is_self_assignable = TRUE
-            AND (review = NULL
-            OR review_is_locked (review) = FALSE)) != 0 THEN
+            AND review_assignment_available_sections (review_assignment) != '{}'
+            AND review.id IS NULL) != 0 THEN
             'SELF_ASSIGN'
         WHEN COUNT(*) FILTER (WHERE (appstatus = 'CHANGES_REQUIRED'
             OR appstatus = 'DRAFT')


### PR DESCRIPTION
Based on PR #956 (meant to be included in `feature/final-decision-fixes` branch)

Missing fix to not display Self-assign when there is another reviewer assigned on all available sections...

Check problem described in task list of issue #953  