### PR TITLE
Prevent adding columns to application and file tables

### DIFF
--- a/plugins/action_modify_record/src/modifyRecord.ts
+++ b/plugins/action_modify_record/src/modifyRecord.ts
@@ -5,6 +5,7 @@ import { DBConnectType } from '../../../src/components/databaseConnect'
 import { mapValues, get } from 'lodash'
 import { objectKeysToSnakeCase, getValidTableName } from '../../../src/components/utilityFunctions'
 import { generateFilterDataFields } from '../../../src/components/data_display/generateFilterDataFields/generateFilterDataFields'
+import config from '../../../src/config'
 
 const modifyRecord: ActionPluginType = async ({ parameters, applicationData, DBConnect }) => {
   const db = databaseMethods(DBConnect)
@@ -91,7 +92,11 @@ const createOrUpdateTable = async (
     .filter(([fieldName]) => !tableAndFields.find(({ column_name }) => column_name === fieldName))
     .map(([fieldName, value]) => ({ fieldName, fieldType: getPostgresType(value) }))
 
-  if (fieldsToCreate.length > 0) await db.createFields(tableName, fieldsToCreate)
+  if (fieldsToCreate.length > 0) {
+    if (config.allowedTablesNoColumns.includes(tableName))
+      throw new Error(`Cannot add columns to table: ${tableName}`)
+    await db.createFields(tableName, fieldsToCreate)
+  }
 }
 
 export default modifyRecord

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,9 @@ const config: { [key: string]: any } = {
   // directly by modifyRecord or display as data views. All other names must
   // have "data_table_" prepended.
   allowedTableNames: ['user', 'organisation', 'application', 'file'],
+  // From the above allowed tables, these ones can be written to, but can't have
+  // columns added (i.e. schema changes):
+  allowedTablesNoColumns: ['application', 'file'],
   filterListMaxLength: 10,
   filterColumnSuffix: '_filter_data', // snake_case,
   isProductionBuild,


### PR DESCRIPTION
We have some protection so that actions can't write to tables other than "data_table_..." and a few key others (in `config.allowedTableNames`

This included "application" table, which we need access to for updating serials, etc. 

However, what we *don't* want is the schema being changed on these tables. Fergus had a "generateText" action that was adding additional columns to the "application" table, which caused errors due to name conflicts.

We need to completely prevent this, as it's a loophole we've overlooked. This PR just makes an additional list of tables that can be written to, but not have columns added. If you try and run an action that would add a column to these, it'll throw an error.