### PR TITLE
#967 Template category export/import fix

### DIFF
--- a/database/snapshotOptions/templateExport.json
+++ b/database/snapshotOptions/templateExport.json
@@ -11,12 +11,19 @@
     "templateStage",
     "templateSection",
     "templateStageReviewLevel",
+    "templateCategory",
     "permissionName",
     "file"
   ],
   "//tablesToUpdateOnInsertFail": "deprecated, in favour of skipTableOnInsertFail",
-  "//skipTableOnInsertFail": "These tables have unique contraint other then ID, they will be skippped if insert fail, and any related records will reference existing record",
-  "skipTableOnInsertFail": ["permissionName", "permissionPolicy", "filter", "file"],
+  "//skipTableOnInsertFail": "These tables have unique constraint other then ID, they will be skipped if insert fail, and any related records will reference existing record",
+  "skipTableOnInsertFail": [
+    "permissionName",
+    "permissionPolicy",
+    "filter",
+    "file",
+    "templateCategory"
+  ],
   "excludeTables": [],
   "insertScriptsLocale": "dev",
   "includeInsertScripts": [],


### PR DESCRIPTION
Fix #967 

Requires front-end https://github.com/openmsupply/conforma-web-app/pull/1443

This is not a complete fix -- there's still cases you can create where this doesn't work properly, but these problems already exist for existing connected elements (e.g. permissionNames), and fixing them would be a whole lot extra. (For example, if you import a template with categories or permissionNames that don't already exist in the system, it'll only create new ones if the "id" *matches* an existing entry -- you'd think the other way round would be the expected behaviour, but 🤷‍♂️. Again, this needs a complete re-write).

However, this will sort out the case we mostly deal with -- exporting a template to import into another (similar) server.

And it doesn't break the linked file import, so that's good.