### PR TITLE
#1445B - Moving isAdmin, isManager and permission names to returned User

### DIFF
--- a/src/components/actions/getApplicationData.ts
+++ b/src/components/actions/getApplicationData.ts
@@ -67,10 +67,16 @@ export const getApplicationData = async (input: {
     ({ code }: { code: string }) => code
   )
 
+  const adminPermission = 'admin' // TODO: Should be added to preferences too
+  const managementPrefName =
+    config?.systemManagerPermissionName ?? config.defaultSystemManagerPermissionName
+
   return {
     action_payload: input?.payload,
     ...applicationData,
     ...userData,
+    isAdmin: !!userData?.permissionNames.includes(adminPermission),
+    isManager: !!userData?.permissionNames.includes(managementPrefName),
     responses: responseData,
     reviewData,
     environmentData,

--- a/src/components/actions/getApplicationData.ts
+++ b/src/components/actions/getApplicationData.ts
@@ -3,6 +3,7 @@ import DBConnect from '../databaseConnect'
 import { BasicObject } from '@openmsupply/expression-evaluator/lib/types'
 import { getAppEntryPointDir } from '../utilityFunctions'
 import config from '../../config'
+import { getUserInfo } from '../permissions/loginHelpers'
 
 // Add more data (such as org/review, etc.) here as required
 export const getApplicationData = async (input: {
@@ -27,9 +28,23 @@ export const getApplicationData = async (input: {
 
   const applicationData = applicationResult ? applicationResult : { applicationId }
 
-  const userData = applicationData?.userId
-    ? await DBConnect.getUserData(applicationData?.userId, applicationData?.orgId)
-    : null
+  const {
+    user: {
+      firstName,
+      lastName,
+      organisation: orgName,
+      username,
+      dateOfBirth,
+      email,
+      permissionNames,
+    },
+  } = await getUserInfo({
+    userId: applicationData.userId,
+    username: applicationData.username,
+    orgId: applicationData.orgId,
+  })
+
+  const userData = { firstName, lastName, orgName, username, dateOfBirth, email, permissionNames }
 
   const responses = await DBConnect.getApplicationResponses(applicationId)
 

--- a/src/components/permissions/loginHelpers.ts
+++ b/src/components/permissions/loginHelpers.ts
@@ -70,29 +70,35 @@ const getUserInfo = async (userOrgParameters: UserOrgParameters) => {
 
   const isAdmin = !!templatePermissionRows.find((row) => !!row?.isAdmin)
 
+  const managementPrefName =
+    config?.systemManagerPermissionName || config.defaultSystemManagerPermissionName
+  const isManager = !!templatePermissionRows.includes(managementPrefName)
+
   return {
     templatePermissions: buildTemplatePermissions(templatePermissionRows),
-    permissionNames: Array.from(
-      new Set(templatePermissionRows.map(({ permissionName }) => permissionName))
-    ),
     JWT: await getSignedJWT({
       userId: userId || newUserId,
       orgId,
       templatePermissionRows,
       sessionId: returnSessionId,
       isAdmin,
+      isManager,
     }),
     user: {
       userId: userId || newUserId,
       username: username || newUsername,
+      permissionNames: Array.from(
+        new Set(templatePermissionRows.map(({ permissionName }) => permissionName))
+      ),
       firstName,
       lastName,
       email,
       dateOfBirth,
       organisation: selectedOrg?.[0],
       sessionId: returnSessionId,
+      isAdmin,
+      isManager,
     },
-    isAdmin,
     orgList,
   }
 }

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -692,16 +692,18 @@ class PostgresDB {
       WHERE id = $1
       `
     const text2 = `
-      SELECT name as "orgName"
-      FROM organisation
-      WHERE id = $1
+    SELECT distinct("orgName"), "permissionName"
+      FROM permissions_all
+      WHERE ("userId" = $1 OR "userId" IS NULL) 
+      AND "orgId" = $2
       `
     try {
       const result = await this.query({ text, values: [userId] })
       const userData = { ...result.rows[0], orgName: null }
       if (orgId) {
-        const orgResult = await this.query({ text: text2, values: [orgId] })
+        const orgResult = await this.query({ text: text2, values: [userId, orgId] })
         userData.orgName = orgResult.rows[0].orgName
+        userData.permissionNames = orgResult.rows.map(({ permissionName }) => permissionName)
       }
       return userData
     } catch (err) {

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -692,18 +692,16 @@ class PostgresDB {
       WHERE id = $1
       `
     const text2 = `
-    SELECT distinct("orgName"), "permissionName"
-      FROM permissions_all
-      WHERE ("userId" = $1 OR "userId" IS NULL) 
-      AND "orgId" = $2
+      SELECT name as "orgName"
+      FROM organisation
+      WHERE id = $1
       `
     try {
       const result = await this.query({ text, values: [userId] })
       const userData = { ...result.rows[0], orgName: null }
       if (orgId) {
-        const orgResult = await this.query({ text: text2, values: [userId, orgId] })
+        const orgResult = await this.query({ text: text2, values: [orgId] })
         userData.orgName = orgResult.rows[0].orgName
-        userData.permissionNames = orgResult.rows.map(({ permissionName }) => permissionName)
       }
       return userData
     } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ const config: { [key: string]: any } = {
   filterListMaxLength: 10,
   filterColumnSuffix: '_filter_data', // snake_case,
   isProductionBuild,
+  defaultSystemManagerPermissionName: 'systemManager',
   ...serverPrefs,
 }
 


### PR DESCRIPTION
Fixes [Front-end PR](https://github.com/openmsupply/conforma-web-app/pull/1448)

### Changes
- Move preferences about SystemManager permissionName to be in back-end of `defaultSystemManagerPermissionName` (default) or project-specific to be defined in `preference.json`.
- Return User including values of `isAdmin`, `isManager` and `permissionNames` (it doesn't seem to be used, but still)
