### PR TITLE
#975(1) Handle core actions

### DIFF
--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -76,11 +76,11 @@ const coreActions: CoreActions = {
       code: 'changeStatus',
       path: '../plugins/action_change_status/src/index.ts',
       name: 'Change Status',
-      trigger: 'ON_APPLICATION_SUBMIT',
+      trigger: 'ON_APPLICATION_RESTART',
       event_code: null,
       sequence: -1,
       condition: true,
-      parameter_queries: { newStatus: 'SUBMITTED' },
+      parameter_queries: { newStatus: 'DRAFT' },
     },
   ],
   [Trigger.OnApplicationSubmit]: [
@@ -148,7 +148,9 @@ const coreActions: CoreActions = {
     // },
 
     // Change outcome to APPROVED if there are no other "changeOutcome" actions
-    // associated with this template
+    // associated with this template.
+    // Used for non-reviewable templates or when there isn't another specific
+    // "changeOutcome" included
     {
       code: 'changeOutcome',
       path: '../plugins/action_change_outcome/src/index.ts',
@@ -226,7 +228,7 @@ const coreActions: CoreActions = {
       code: 'changeStatus',
       path: '../plugins/action_change_status/src/index.ts',
       name: 'Change Status',
-      trigger: 'ON_REVIEW_CREATE',
+      trigger: 'ON_REVIEW_RESTART',
       event_code: '',
       sequence: -1,
       condition: true,
@@ -381,10 +383,14 @@ const coreActions: CoreActions = {
       event_code: null,
       sequence: -1,
       condition: {
-        operator: 'OR',
+        operator: 'AND',
         children: [
           {
-            operator: 'AND',
+            operator: 'objectProperties',
+            children: ['applicationData.reviewData.latestDecision.decision'],
+          },
+          {
+            operator: 'OR',
             children: [
               {
                 operator: '=',
@@ -397,15 +403,6 @@ const coreActions: CoreActions = {
                 ],
               },
               {
-                operator: 'objectProperties',
-                children: ['applicationData.reviewData.isLastStage'],
-              },
-            ],
-          },
-          {
-            operator: 'AND',
-            children: [
-              {
                 operator: '=',
                 children: [
                   {
@@ -414,10 +411,6 @@ const coreActions: CoreActions = {
                   },
                   'NON_CONFORM',
                 ],
-              },
-              {
-                operator: 'objectProperties',
-                children: ['applicationData.reviewData.isLastLevel'],
               },
             ],
           },

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -91,7 +91,7 @@ const coreActions: CoreActions = {
       name: 'Change Status',
       trigger: 'ON_APPLICATION_SUBMIT',
       event_code: null,
-      sequence: -5,
+      sequence: -6,
       condition: true,
       parameter_queries: { newStatus: 'SUBMITTED' },
     },
@@ -102,7 +102,7 @@ const coreActions: CoreActions = {
       name: 'Trim duplicate responses',
       trigger: 'ON_APPLICATION_SUBMIT',
       event_code: null,
-      sequence: -4,
+      sequence: -5,
       condition: true,
       parameter_queries: {},
     },
@@ -113,7 +113,7 @@ const coreActions: CoreActions = {
       name: 'Generate Review Assignment Records',
       trigger: 'ON_APPLICATION_SUBMIT',
       event_code: null,
-      sequence: -3,
+      sequence: -4,
       condition: true,
       parameter_queries: {},
     },
@@ -125,7 +125,7 @@ const coreActions: CoreActions = {
       name: 'Clean up application files',
       trigger: 'ON_APPLICATION_SUBMIT',
       event_code: null,
-      sequence: -2,
+      sequence: -3,
       condition: true,
       parameter_queries: {},
     },
@@ -137,7 +137,7 @@ const coreActions: CoreActions = {
     //   name: 'Update Review Statuses',
     //   trigger: 'ON_APPLICATION_SUBMIT',
     //   event_code: null,
-    //   sequence: -1,
+    //   sequence: -2,
     //   condition: true,
     //   parameter_queries: {
     //     changedResponses: {
@@ -146,6 +146,39 @@ const coreActions: CoreActions = {
     //     },
     //   },
     // },
+
+    // Change outcome to APPROVED if there are no other "changeOutcome" actions
+    // associated with this template
+    {
+      code: 'changeOutcome',
+      path: '../plugins/action_change_outcome/src/index.ts',
+      name: 'Change Outcome',
+      trigger: 'ON_APPLICATION_SUBMIT',
+      event_code: null,
+      sequence: -1,
+      condition: {
+        operator: '=',
+        children: [
+          {
+            operator: 'graphQL',
+            children: [
+              'query getChangeOutcomeActionCount($templateId: Int!) {\n  templateActions(\n    condition: { templateId: $templateId, actionCode: "changeOutcome" }\n  ) {\n    totalCount\n  }\n}\n',
+              'graphQLEndpoint',
+              ['templateId'],
+              {
+                operator: 'objectProperties',
+                children: ['applicationData.templateId', null],
+              },
+              'templateActions.totalCount',
+            ],
+          },
+          0,
+        ],
+      },
+      parameter_queries: {
+        newOutcome: 'APPROVED',
+      },
+    },
   ],
   [Trigger.OnReviewAssign]: [
     // If any reviews already exist for the current assignment, set them to

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -1,0 +1,239 @@
+/*
+Contains core actions that must be run for the system to function correctly.
+These should NEVER be configurable or removable by template configurations, so
+they've been hard-coded here in order to:
+- be maintained in one place: a change can be made without having to
+  re-configure all templates
+- prevent accidental misconfiguration or removal
+*/
+
+import { Trigger } from '../../generated/graphql'
+import { ActionInTemplate } from '../../types'
+
+type CoreActions = {
+  [key in Trigger]?: Omit<ActionInTemplate, 'parameters_evaluated'>[]
+}
+
+const coreActions: CoreActions = {
+  [Trigger.OnApplicationCreate]: [
+    // Generate serial for application when first created
+    // Can be over-ridden by specifying a template action
+    {
+      code: 'generateTextString',
+      path: '../plugins/action_generate_text_string/src/index.ts',
+      name: 'Generate Text String',
+      trigger: 'ON_APPLICATION_CREATE',
+      event_code: null,
+      sequence: -3,
+      condition: true,
+      parameter_queries: {
+        pattern: 'S-[A-Z]{3}-<+dddd>',
+        fieldName: 'serial',
+        tableName: 'application',
+        counterName: {
+          operator: 'objectProperties',
+          children: ['applicationData.templateCode'],
+        },
+        updateRecord: true,
+      },
+    },
+    // Set initial stage
+    {
+      code: 'incrementStage',
+      path: '../plugins/action_increment_stage/src/index.ts',
+      name: 'Increment Stage',
+      trigger: 'ON_APPLICATION_CREATE',
+      event_code: null,
+      sequence: -2,
+      condition: true,
+      parameter_queries: {},
+    },
+    // Generate name for application based on template code and serial
+    {
+      code: 'generateTextString',
+      path: '../plugins/action_generate_text_string/src/index.ts',
+      name: 'Generate Text String',
+      trigger: 'ON_APPLICATION_CREATE',
+      event_code: null,
+      // Sequence set high so it goes AFTER template actions
+      sequence: 100,
+      condition: true,
+      parameter_queries: {
+        pattern: '<?templateName> - <?serial>',
+        fieldName: 'name',
+        tableName: 'application',
+        customFields: {
+          serial: 'applicationData.applicationSerial',
+          templateName: 'applicationData.templateName',
+        },
+        updateRecord: true,
+      },
+    },
+  ],
+  [Trigger.OnApplicationSubmit]: [
+    // Set status = SUBMITTED
+    {
+      code: 'changeStatus',
+      path: '../plugins/action_change_status/src/index.ts',
+      name: 'Change Status',
+      trigger: 'ON_APPLICATION_SUBMIT',
+      event_code: null,
+      sequence: -4,
+      condition: true,
+      parameter_queries: { newStatus: 'SUBMITTED' },
+    },
+    // Trim application responses that haven't changed since previous submission
+    {
+      code: 'trimResponses',
+      path: '../plugins/action_trim_responses/src/index.ts',
+      name: 'Trim duplicate responses',
+      trigger: 'ON_APPLICATION_SUBMIT',
+      event_code: null,
+      sequence: -3,
+      condition: true,
+      parameter_queries: {},
+    },
+    // Create review assignment records for the next review level
+    {
+      code: 'generateReviewAssignments',
+      path: '../plugins/action_generate_review_assignment_records/src/index.ts',
+      name: 'Generate Review Assignment Records',
+      trigger: 'ON_APPLICATION_SUBMIT',
+      event_code: null,
+      sequence: -2,
+      condition: true,
+      parameter_queries: {},
+    },
+    // Remove any files that were uploaded but not submitted as part of the
+    // application
+    {
+      code: 'cleanupFiles',
+      path: '../plugins/action_files_cleanup/src/index.ts',
+      name: 'Clean up application files',
+      trigger: 'ON_APPLICATION_SUBMIT',
+      event_code: null,
+      sequence: -1,
+      condition: true,
+      parameter_queries: {},
+    },
+  ],
+  [Trigger.OnReviewAssign]: [
+    // TO-DO: this is not correct -- needs to be worked out exactly
+    {
+      code: 'changeStatus',
+      path: '../plugins/action_change_status/src/index.ts',
+      name: 'Change Status',
+      trigger: 'ON_REVIEW_ASSIGN',
+      event_code: null,
+      sequence: 1,
+      condition: {
+        operator: '!=',
+        children: [
+          {
+            operator: 'objectProperties',
+            children: ['applicationData.reviewData', null],
+          },
+          null,
+        ],
+      },
+      parameter_queries: {
+        isReview: true,
+        reviewId: {
+          operator: 'objectProperties',
+          children: ['applicationData.reviewData.reviewId', null],
+        },
+        newStatus: 'DRAFT',
+      },
+    },
+  ],
+  [Trigger.OnReviewCreate]: [
+    {
+      code: 'changeStatus',
+      path: '../plugins/action_change_status/src/index.ts',
+      name: 'Change Status',
+      trigger: 'ON_REVIEW_CREATE',
+      event_code: '',
+      sequence: -1,
+      condition: true,
+      parameter_queries: { newStatus: 'DRAFT' },
+    },
+  ],
+  [Trigger.OnReviewRestart]: [
+    // Is this even used?
+  ],
+  [Trigger.OnReviewSubmit]: [
+    // If sent back to applicant for further information (LOQ), this sets which
+    // review responses are visible to the applicant
+    {
+      code: 'updateReviewVisibility',
+      path: '../plugins/action_update_review_visibility/src/index.ts',
+      name: "Update Applicant's Review Visibility",
+      trigger: 'ON_REVIEW_SUBMIT',
+      event_code: '',
+      sequence: -3,
+      condition: {
+        operator: 'AND',
+        children: [
+          {
+            operator: '=',
+            children: [
+              {
+                operator: 'objectProperties',
+                children: ['applicationData.reviewData.latestDecision.decision'],
+              },
+              'LIST_OF_QUESTIONS',
+            ],
+          },
+          {
+            operator: 'objectProperties',
+            children: ['applicationData.reviewData.isLastLevel'],
+          },
+        ],
+      },
+      parameter_queries: {},
+    },
+    // Set review status => SUBMITTED
+    {
+      code: 'changeStatus',
+      path: '../plugins/action_change_status/src/index.ts',
+      name: 'Change Status',
+      trigger: 'ON_REVIEW_SUBMIT',
+      event_code: '',
+      sequence: -2,
+      condition: true,
+      parameter_queries: { newStatus: 'SUBMITTED' },
+    },
+    // Remove any review responses that have not changed since previous review
+    {
+      code: 'trimResponses',
+      path: '../plugins/action_trim_responses/src/index.ts',
+      name: 'Trim duplicate review responses',
+      trigger: 'ON_REVIEW_SUBMIT',
+      event_code: '',
+      sequence: -1,
+      condition: true,
+      parameter_queries: {
+        operator: 'objectProperties',
+        children: ['outputCumulative.reviewStatusHistoryTimestamp'],
+      },
+    },
+    // Generate review assignments for next stage/level
+    {
+      code: 'generateReviewAssignments',
+      path: '../plugins/action_generate_review_assignment_records/src/index.ts',
+      name: 'Generate Review Assignment Records',
+      trigger: 'ON_REVIEW_SUBMIT',
+      event_code: null,
+      // Needs to go AFTER any possible "incrementStage" action
+      sequence: 100,
+      condition: true,
+      parameter_queries: {},
+    },
+  ],
+  [Trigger.OnReviewUnassign]: [
+    // Is this used?
+    // Maybe needs to set status to "DISCONTINUED"?
+  ],
+}
+
+export default coreActions

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -48,7 +48,7 @@ const coreActions: CoreActions = {
       condition: true,
       parameter_queries: {},
     },
-    // Generate name for application based on template code and serial
+    // Generate initial name for application based on template code and serial
     {
       code: 'generateTextString',
       path: '../plugins/action_generate_text_string/src/index.ts',
@@ -71,7 +71,9 @@ const coreActions: CoreActions = {
     },
   ],
   [Trigger.OnApplicationRestart]: [
-    // Set status = DRAFT
+    // Change application status from CHANGES REQUIRED to DRAFT when the
+    // applicant restarts an application with to-do updates (as requested in
+    // review)
     {
       code: 'changeStatus',
       path: '../plugins/action_change_status/src/index.ts',
@@ -84,7 +86,7 @@ const coreActions: CoreActions = {
     },
   ],
   [Trigger.OnApplicationSubmit]: [
-    // Set status = SUBMITTED
+    // Set status = SUBMITTED when applicant submits (or re-submits)
     {
       code: 'changeStatus',
       path: '../plugins/action_change_status/src/index.ts',
@@ -95,7 +97,8 @@ const coreActions: CoreActions = {
       condition: true,
       parameter_queries: { newStatus: 'SUBMITTED' },
     },
-    // Trim application responses that haven't changed since previous submission
+    // Remove duplicate/unchanged application responses since previous
+    // application submission
     {
       code: 'trimResponses',
       path: '../plugins/action_trim_responses/src/index.ts',
@@ -106,7 +109,8 @@ const coreActions: CoreActions = {
       condition: true,
       parameter_queries: {},
     },
-    // Create review assignment records for the next review level
+    // Generate level 1 review assignments in current stage after application is
+    // submitted by the applicant
     {
       code: 'generateReviewAssignments',
       path: '../plugins/action_generate_review_assignment_records/src/index.ts',
@@ -129,20 +133,16 @@ const coreActions: CoreActions = {
       condition: true,
       parameter_queries: {},
     },
-    // Update review statuses
+    // Update reviews status with review assignment linked to changed responses
+    // by applicant when application is resubmitted.
     // TO-DO: Un-comment once action is re-implemented
     // {
-    //   code: 'updateReviewStatuses',
-    //   path: '../plugins/action_update_review_statuses/src/index.ts',
-    //   name: 'Update Review Statuses',
-    //   trigger: 'ON_APPLICATION_SUBMIT',
-    //   event_code: null,
-    //   sequence: -2,
-    //   condition: true,
-    //   parameter_queries: {
-    //     changedResponses: {
-    //       operator: 'objectProperties',
-    //       children: ['outputCumulative.updatedResponses'],
+    //   code: 'updateReviewStatuses', path:
+    //   '../plugins/action_update_review_statuses/src/index.ts', name: 'Update
+    //   Review Statuses', trigger: 'ON_APPLICATION_SUBMIT', event_code: null,
+    //   sequence: -2, condition: true, parameter_queries: { changedResponses: {
+    //   operator: 'objectProperties', children:
+    //   ['outputCumulative.updatedResponses'],
     //     },
     //   },
     // },
@@ -210,7 +210,7 @@ const coreActions: CoreActions = {
     },
   ],
   [Trigger.OnReviewCreate]: [
-    // Set to DRAFT
+    // Set to DRAFT when reviewer starts their review
     {
       code: 'changeStatus',
       path: '../plugins/action_change_status/src/index.ts',
@@ -223,7 +223,8 @@ const coreActions: CoreActions = {
     },
   ],
   [Trigger.OnReviewRestart]: [
-    // Set to DRAFT
+    // Set to DRAFT when reviewer re-starts their review after an applicant
+    // re-submission or change request from higher-level reviewer
     {
       code: 'changeStatus',
       path: '../plugins/action_change_status/src/index.ts',
@@ -236,7 +237,7 @@ const coreActions: CoreActions = {
     },
   ],
   [Trigger.OnReviewSubmit]: [
-    // Set review status => SUBMITTED
+    // Set review status to SUBMITTED when reviews submits review
     {
       code: 'changeStatus',
       path: '../plugins/action_change_status/src/index.ts',
@@ -248,7 +249,8 @@ const coreActions: CoreActions = {
       parameter_queries: { newStatus: 'SUBMITTED' },
     },
 
-    // Remove any review responses that have not changed since previous review
+    // Remove duplicated and unchanged responses or ones without a decision made
+    // when review is re-submitted by the reviewer.
     {
       code: 'trimResponses',
       path: '../plugins/action_trim_responses/src/index.ts',
@@ -262,20 +264,16 @@ const coreActions: CoreActions = {
         children: ['outputCumulative.reviewStatusHistoryTimestamp'],
       },
     },
-    // Update review statuses
+    // Update other review status to PENDING or CHANGES REQUESTED after one
+    // review is submitted to another reviewer in the chain of review-levels
     // TO-DO: Un-comment once action is re-implemented
     // {
-    //   code: 'updateReviewStatuses',
-    //   path: '../plugins/action_update_review_statuses/src/index.ts',
-    //   name: 'Update Review Statuses',
-    //   trigger: 'ON_REVIEW_SUBMIT',
-    //   event_code: null,
-    //   sequence: -5,
-    //   condition: true,
-    //   parameter_queries: {
-    //     changedResponses: {
-    //       operator: 'objectProperties',
-    //       children: ['outputCumulative.updatedResponses'],
+    //   code: 'updateReviewStatuses', path:
+    //   '../plugins/action_update_review_statuses/src/index.ts', name: 'Update
+    //   Review Statuses', trigger: 'ON_REVIEW_SUBMIT', event_code: null,
+    //   sequence: -5, condition: true, parameter_queries: { changedResponses: {
+    //   operator: 'objectProperties', children:
+    //   ['outputCumulative.updatedResponses'],
     //     },
     //   },
     // },

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -332,9 +332,8 @@ const coreActions: CoreActions = {
       },
       parameter_queries: {},
     },
-    // Will always increment stage if and only if last-level decision is
-    // "CONFORM". Any other cases for incrementing stage must be specified in
-    // template actions.
+    // Will increment stage if and only if last-level decision is "CONFORM". Any
+    // other cases for incrementing stage must be specified in template actions.
     {
       code: 'incrementStage',
       path: '../plugins/action_increment_stage/src/index.ts',
@@ -345,6 +344,10 @@ const coreActions: CoreActions = {
       condition: {
         operator: 'AND',
         children: [
+          {
+            operator: 'objectProperties',
+            children: ['applicationData.reviewData.isLastStage'],
+          },
           {
             operator: 'objectProperties',
             children: ['applicationData.reviewData.isLastLevel'],

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -149,7 +149,7 @@ const coreActions: CoreActions = {
 
     // Change outcome to APPROVED if there are no other "changeOutcome" actions
     // associated with this template.
-    // Used for non-reviewable templates or when there isn't another specific
+    // Used for non-reviewable templates when there isn't another specific
     // "changeOutcome" included
     {
       code: 'changeOutcome',
@@ -159,22 +159,46 @@ const coreActions: CoreActions = {
       event_code: null,
       sequence: -1,
       condition: {
-        operator: '=',
+        operator: 'AND',
         children: [
           {
-            operator: 'graphQL',
+            operator: '=',
             children: [
-              'query getChangeOutcomeActionCount($templateId: Int!) {\n  templateActions(\n    condition: { templateId: $templateId, actionCode: "changeOutcome" }\n  ) {\n    totalCount\n  }\n}\n',
-              'graphQLEndpoint',
-              ['templateId'],
               {
-                operator: 'objectProperties',
-                children: ['applicationData.templateId', null],
+                operator: 'graphQL',
+                children: [
+                  'query getChangeOutcomeActionCount($templateId: Int!) {\n  templateActions(\n    condition: { templateId: $templateId, actionCode: "changeOutcome" }\n  ) {\n    totalCount\n  }\n}\n',
+                  'graphQLEndpoint',
+                  ['templateId'],
+                  {
+                    operator: 'objectProperties',
+                    children: ['applicationData.templateId', null],
+                  },
+                  'templateActions.totalCount',
+                ],
               },
-              'templateActions.totalCount',
+              0,
             ],
           },
-          0,
+          {
+            operator: '=',
+            children: [
+              {
+                operator: 'graphQL',
+                children: [
+                  'query getTotalReviewCount($templateId: Int!) {\n  templateStageReviewLevels(filter: {stage: {templateId: {equalTo: $templateId}}}) {\n    totalCount\n  }\n}',
+                  'graphQLEndpoint',
+                  ['templateId'],
+                  {
+                    operator: 'objectProperties',
+                    children: ['applicationData.templateId', null],
+                  },
+                  'templateStageReviewLevels.totalCount',
+                ],
+              },
+              0,
+            ],
+          },
         ],
       },
       parameter_queries: {

--- a/src/components/actions/processTrigger.ts
+++ b/src/components/actions/processTrigger.ts
@@ -2,6 +2,7 @@ import { TriggerPayload, ActionResult } from '../../types'
 import DBConnect from '../databaseConnect'
 import { actionLibrary } from '../pluginsConnect'
 import { EvaluatorNode } from '@openmsupply/expression-evaluator/lib/types'
+import coreActions from './coreActions'
 import { executeAction } from './executeAction'
 import { ActionQueueStatus, TriggerQueueStatus } from '../../generated/graphql'
 import { swapOutAliasedAction } from './helpers'
@@ -30,7 +31,10 @@ export async function processTrigger(payload: TriggerPayload): Promise<ActionRes
   const actionsSequential = resolvedActions.filter(({ sequence }) => !!sequence)
   const actionsAsync = resolvedActions.filter(({ sequence }) => !sequence)
 
-  for (const action of [...actionsAsync, ...actionsSequential]) {
+  // Get core actions for the current trigger
+  const currentCoreActions = coreActions?.[trigger] ?? []
+
+  for (const action of [...actionsAsync, ...currentCoreActions, ...actionsSequential]) {
     // Add all actions to Action Queue
     await DBConnect.addActionQueue({
       trigger_event: trigger_id,


### PR DESCRIPTION
Fix #975 

Oh my god, I can't believe we didn't do this ages ago -- it's so much easier to keep a handle on these core actions if they're all in one place like this and it was incredibly simple to implement. Works a treat :) 

I haven't actually got all the actions correct yet -- @nmadruga, you and I should sit down together and go through them carefully, but it's so much easier to know we can do it once and it'll be correct everywhere!

Still to do:

- [x] Fetch serial no "pattern" from template so it can be configurable #978 
- [x] Get exact core action collection sorted (requires #977 )
- [ ] ~~Find a way to show a warning when loading a snapshot with the core actions still in place~~