### PR TITLE
975(2) Core actions serial pattern

### DIFF
--- a/database/buildSchema/07_template.sql
+++ b/database/buildSchema/07_template.sql
@@ -16,6 +16,7 @@ CREATE TABLE public.template (
     status public.template_status,
     submission_message jsonb DEFAULT '"Thank you! Your application has been submitted."' ::jsonb,
     icon varchar,
+    serial_pattern varchar,
     template_category_id integer REFERENCES public.template_category (id),
     version_timestamp timestamptz DEFAULT CURRENT_TIMESTAMP,
     version integer DEFAULT 1

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -663,7 +663,7 @@ const migrateData = async () => {
       DROP TYPE public.review_status_old; 
       `)
 
-    console.log('Add serial_pattern field to template')
+    console.log(' - Add serial_pattern field to template')
     await DB.changeSchema(`
       ALTER TABLE public.template
         ADD COLUMN IF NOT EXISTS serial_pattern varchar;

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -662,6 +662,12 @@ const migrateData = async () => {
     await DB.changeSchema(`
       DROP TYPE public.review_status_old; 
       `)
+
+    console.log('Add serial_pattern field to template')
+    await DB.changeSchema(`
+      ALTER TABLE public.template
+        ADD COLUMN IF NOT EXISTS serial_pattern varchar;
+    `)
   }
 
   // Other version migrations continue here...

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -7,11 +7,28 @@ they've been hard-coded here in order to:
 - prevent accidental misconfiguration or removal
 */
 
+import DBConnect from '../databaseConnect'
 import { Trigger } from '../../generated/graphql'
 import { ActionInTemplate } from '../../types'
 
 type CoreActions = {
   [key in Trigger]?: Omit<ActionInTemplate, 'parameters_evaluated'>[]
+}
+
+export const getCoreActions = async (trigger: Trigger, templateId: number) => {
+  const currentCoreActions = coreActions?.[trigger] ?? []
+
+  // Inject configuration over-rides for a limited selection of core action
+  // parameters (currently only serialPattern)
+  switch (trigger) {
+    case Trigger.OnApplicationCreate:
+      const serialPattern = await DBConnect.getTemplateSerialPattern(templateId)
+      console.log('serialPattern', serialPattern)
+      if (serialPattern) currentCoreActions[0].parameter_queries.pattern = serialPattern
+    // Other cases as required...
+  }
+
+  return currentCoreActions
 }
 
 const coreActions: CoreActions = {
@@ -235,5 +252,3 @@ const coreActions: CoreActions = {
     // Maybe needs to set status to "DISCONTINUED"?
   ],
 }
-
-export default coreActions

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -23,7 +23,6 @@ export const getCoreActions = async (trigger: Trigger, templateId: number) => {
   switch (trigger) {
     case Trigger.OnApplicationCreate:
       const serialPattern = await DBConnect.getTemplateSerialPattern(templateId)
-      console.log('serialPattern', serialPattern)
       if (serialPattern) currentCoreActions[0].parameter_queries.pattern = serialPattern
     // Other cases as required...
   }

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -52,6 +52,18 @@ const coreActions: CoreActions = {
           children: ['applicationData.templateCode'],
         },
         updateRecord: true,
+        // Provides functionality to support `<?year>` in pattern string.
+        // Add more functionality here as required
+        customFields: { year: 'year' },
+        additionalData: {
+          operator: 'buildObject',
+          properties: [
+            {
+              key: 'year',
+              value: { operator: 'objectFunctions', children: ['functions.getYear'] },
+            },
+          ],
+        },
       },
     },
     // Set initial stage

--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -413,6 +413,10 @@ const coreActions: CoreActions = {
         children: [
           {
             operator: 'objectProperties',
+            children: ['applicationData.reviewData.isLastStage'],
+          },
+          {
+            operator: 'objectProperties',
             children: ['applicationData.reviewData.latestDecision.decision'],
           },
           {

--- a/src/components/actions/processTrigger.ts
+++ b/src/components/actions/processTrigger.ts
@@ -2,7 +2,7 @@ import { TriggerPayload, ActionResult } from '../../types'
 import DBConnect from '../databaseConnect'
 import { actionLibrary } from '../pluginsConnect'
 import { EvaluatorNode } from '@openmsupply/expression-evaluator/lib/types'
-import coreActions from './coreActions'
+import { getCoreActions } from './coreActions'
 import { executeAction } from './executeAction'
 import { ActionQueueStatus, TriggerQueueStatus } from '../../generated/graphql'
 import { swapOutAliasedAction } from './helpers'
@@ -32,9 +32,9 @@ export async function processTrigger(payload: TriggerPayload): Promise<ActionRes
   const actionsAsync = resolvedActions.filter(({ sequence }) => !sequence)
 
   // Get core actions for the current trigger
-  const currentCoreActions = coreActions?.[trigger] ?? []
+  const coreActions = await getCoreActions(trigger, templateId)
 
-  for (const action of [...actionsAsync, ...currentCoreActions, ...actionsSequential]) {
+  for (const action of [...actionsAsync, ...coreActions, ...actionsSequential]) {
     // Add all actions to Action Queue
     await DBConnect.addActionQueue({
       trigger_event: trigger_id,

--- a/src/components/databaseConnect.ts
+++ b/src/components/databaseConnect.ts
@@ -60,6 +60,8 @@ class DBConnect {
 
   public getActionsByTemplateId = PostgresDB.getActionsByTemplateId
 
+  public getTemplateSerialPattern = PostgresDB.getTemplateSerialPattern
+
   public getSingleTemplateAction = PostgresDB.getSingleTemplateAction
 
   public updateActionPlugin = PostgresDB.updateActionPlugin

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -529,11 +529,24 @@ class PostgresDB {
     return result.rows[0].template_id
   }
 
+  public getTemplateSerialPattern = async (templateId: number) => {
+    const text = `
+      SELECT serial_pattern FROM template
+      WHERE id = $1`
+
+    try {
+      const result = await this.query({ text, values: [templateId] })
+      return result.rows[0].serial_pattern
+    } catch (err) {
+      throw err
+    }
+  }
+
   public getActionsByTemplateId = async (
     templateId: number,
     trigger: Trigger
   ): Promise<ActionInTemplate[]> => {
-    const text = `SELECT action_plugin.code, action_plugin.path, action_plugin.name, trigger, template_action.event_code AS event_code, sequence, condition, parameter_queries 
+    const text = `SELECT action_plugin.code, action_plugin.path, action_plugin.name, trigger, template_action.event_code AS event_code, sequence, condition, parameter_queries
     FROM template 
     JOIN template_action ON template.id = template_action.template_id 
     JOIN action_plugin ON template_action.action_code = action_plugin.code 

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -516,6 +516,7 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -4086,6 +4087,7 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -9913,6 +9915,7 @@ export type FileTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -18208,6 +18211,7 @@ export type ReviewAssignmentTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -20604,6 +20608,7 @@ export type Template = Node & {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   /** Reads a single `TemplateCategory` that is related to this `Template`. */
   templateCategory?: Maybe<TemplateCategory>;
   /** Reads and enables pagination through a set of `TemplateSection`. */
@@ -21011,6 +21016,7 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -21244,6 +21250,8 @@ export type TemplateCondition = {
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   /** Checks for equality with the object’s `version` field. */
   version?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `serialPattern` field. */
+  serialPattern?: Maybe<Scalars['String']>;
 };
 
 export type TemplateElement = Node & {
@@ -21789,6 +21797,8 @@ export type TemplateFilter = {
   versionTimestamp?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `version` field. */
   version?: Maybe<IntFilter>;
+  /** Filter by the object’s `serialPattern` field. */
+  serialPattern?: Maybe<StringFilter>;
   /** Filter by the object’s `templateSections` relation. */
   templateSections?: Maybe<TemplateToManyTemplateSectionFilter>;
   /** Some related `templateSections` exist. */
@@ -22107,6 +22117,7 @@ export type TemplateFilterJoinTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -22143,6 +22154,7 @@ export type TemplateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -22348,6 +22360,7 @@ export type TemplatePatch = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -22681,6 +22694,7 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -22979,6 +22993,7 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -23072,6 +23087,8 @@ export enum TemplatesOrderBy {
   VersionTimestampDesc = 'VERSION_TIMESTAMP_DESC',
   VersionAsc = 'VERSION_ASC',
   VersionDesc = 'VERSION_DESC',
+  SerialPatternAsc = 'SERIAL_PATTERN_ASC',
+  SerialPatternDesc = 'SERIAL_PATTERN_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -23636,6 +23653,7 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -23802,6 +23820,7 @@ export type TemplateTemplateCategoryIdFkeyTemplateCreateInput = {
   icon?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -24655,6 +24674,7 @@ export type TriggerScheduleTemplateIdFkeyTemplateCreateInput = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28172,6 +28192,7 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28200,6 +28221,7 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28228,6 +28250,7 @@ export type UpdateTemplateOnFileForFileTemplateIdFkeyPatch = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28256,6 +28279,7 @@ export type UpdateTemplateOnReviewAssignmentForReviewAssignmentTemplateIdFkeyPat
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28284,6 +28308,7 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28312,6 +28337,7 @@ export type UpdateTemplateOnTemplateFilterJoinForTemplateFilterJoinTemplateIdFke
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28339,6 +28365,7 @@ export type UpdateTemplateOnTemplateForTemplateTemplateCategoryIdFkeyPatch = {
   icon?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28367,6 +28394,7 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28395,6 +28423,7 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28423,6 +28452,7 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -28451,6 +28481,7 @@ export type UpdateTemplateOnTriggerScheduleForTriggerScheduleTemplateIdFkeyPatch
   templateCategoryId?: Maybe<Scalars['Int']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   version?: Maybe<Scalars['Int']>;
+  serialPattern?: Maybe<Scalars['String']>;
   templateCategoryToTemplateCategoryId?: Maybe<TemplateTemplateCategoryIdFkeyInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
@@ -37094,6 +37125,7 @@ export type TemplateResolvers<ContextType = any, ParentType extends ResolversPar
   templateCategoryId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   versionTimestamp?: Resolver<Maybe<ResolversTypes['Datetime']>, ParentType, ContextType>;
   version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  serialPattern?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   templateCategory?: Resolver<Maybe<ResolversTypes['TemplateCategory']>, ParentType, ContextType>;
   templateSections?: Resolver<ResolversTypes['TemplateSectionsConnection'], ParentType, ContextType, RequireFields<TemplateTemplateSectionsArgs, 'orderBy'>>;
   templateStages?: Resolver<ResolversTypes['TemplateStagesConnection'], ParentType, ContextType, RequireFields<TemplateTemplateStagesArgs, 'orderBy'>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface ActionInTemplate {
   condition: EvaluatorNode
   parameter_queries: { [key: string]: any }
   parameters_evaluated: { [key: string]: any }
+  serial_pattern?: string
 }
 
 export interface ActionSequential extends ActionInTemplate {


### PR DESCRIPTION
Continuing implementation of #975

Edit from front-end using PR https://github.com/openmsupply/conforma-web-app/pull/1453

Adds "serial_pattern" field to "template" table, which is used by the core action to create the initial application serial.