### PR TITLE
Quick fix - remove current review from associated reviews to update

### DIFF
--- a/plugins/action_update_review_status/src/updateReviewStatuses.ts
+++ b/plugins/action_update_review_status/src/updateReviewStatuses.ts
@@ -60,6 +60,8 @@ const updateReviewStatuses: ActionPluginType = async ({
     const reviews = (await db.getAssociatedReviews(applicationId, stageNumber))
       // Ignore all "Discontinued" reviews
       .filter(({ reviewStatus }) => reviewStatus !== ReviewStatus.Discontinued)
+      // Ignore current review
+      .filter(({ reviewId: id }) => id !== reviewId)
 
     // APPLICATION SUBMISSIONS:
     if (triggeredBy === 'APPLICATION') {


### PR DESCRIPTION
Fixes #985
 filter out the current review from list of associated reviews