### PR TITLE
#109T Fix updateReviewStatuses action not considering its Triggered by Review when passing reviewId

### DIFF
--- a/src/components/actions/coreActions.ts
+++ b/src/components/actions/coreActions.ts
@@ -336,6 +336,10 @@ const coreActions: CoreActions = {
           operator: 'objectProperties',
           children: ['outputCumulative.updatedResponses'],
         },
+        reviewId: {
+          operator: 'objectProperties',
+          children: ['applicationData.reviewData.reviewId'],
+        },
       },
     },
 


### PR DESCRIPTION
Fixes https://github.com/openmsupply/conforma-templates/issues/109

Just a change on `updatedReviewStatuses` action that caused a regression. The action was supposed to receive the `reviewId` and interpret this action as triggered by Review (it was considering it was triggered by Application before)

Fix problem with re-submitting a review wasn't changing the consolidation review status

### Testing
- Check sending `Changes Requested` to a lower level reviewer while on a consolidation review
  - The lower level reviewer should be able to re-submit (but set another Rejection) and send again as Non-conform
  - This issue fixes that now the Consolidator should be able to do a Re-review of the consolidation
- Also test sending RFI to Applicant
  - Check that Application re-submission is also working