### PR TITLE
review_status migration fix

### DIFF
--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -619,6 +619,12 @@ const migrateData = async () => {
     `)
 
     console.log(' - Simplify how we handle "locked" reviews')
+    // We need to drop these first so we can subsequently manipulate
+    // review_status and review_status_old.
+    await DB.changeSchema(`
+      DROP VIEW IF EXISTS assigned_sections_by_stage_and_level CASCADE;
+      DROP TYPE IF EXISTS public.review_status_old;
+    `)
     await DB.changeSchema(`
       ALTER TABLE public.review_assignment DROP column IF EXISTS
       is_locked;


### PR DESCRIPTION
So the problem was the existing migration code that removes some of the status values from the review_status enum (by creating a new one, then renaming) was failing, because of a new VIEW that had been made recently: `assigned_sections_by_stage_and_level`.

Because of that view, the command to migrate the type of the status column in review_status_history didn't work:
```
      ALTER TABLE review_status_history
        ALTER COLUMN status TYPE public.review_status
        USING status::text::public.review_status;
```

Gives an error as it can't change it as it's in use by a view.

Solution (I think) is to DROP the view earlier in the migration code so the rest of it can run as it used to.

@nmadruga can you check if this fixes the list problem you were having? I think it should as the errors you were getting seem related to missing functions due to a failed review_status function.