### PR TITLE
Remove applicant defaults from sendNotification

### DIFF
--- a/documentation/List-of-Action-plugins.md
+++ b/documentation/List-of-Action-plugins.md
@@ -636,9 +636,9 @@ SMTP_PASSWORD=<password>
 
 `subject` and `message` are just the email subject line and message
 
-`to (email)`, `cc`, `bcc` -- the email address(es) to send the email to, in the "to" "cc" and "bcc" fields, respectively. Can be a string (single email address) or an array of strings if multiple recipients. If not supplied, will use the "email" field from `applicationData`.
+`to (email)`, `cc`, `bcc` -- the email address(es) to send the email to, in the "to" "cc" and "bcc" fields, respectively. Can be a string (single email address) or an array of strings if multiple recipients.
 
-`userId` for the notification recipient. If not supplied, it will be taken from `applicationData`.
+`userId` for the notification recipient.
 
 `fromName` / `fromEmail` refer to who the apparent sender of the email is. Default value(s) should be supplied in `config.json`, but can be over-ridden on a case-by-case basis.
 

--- a/plugins/action_send_notification/src/sendNotification.ts
+++ b/plugins/action_send_notification/src/sendNotification.ts
@@ -27,8 +27,8 @@ const sendNotification: ActionPluginType = async ({ parameters, applicationData,
   const suppressEmail = other?.suppressEmail ?? false
 
   const {
-    userId = applicationData?.userId,
-    email = applicationData?.email,
+    userId,
+    email,
     to = email,
     cc,
     bcc,


### PR DESCRIPTION
The sendNotification action was defaulting to the applicant userId and email address if these fields weren't specified in the Action, which is not what we want in many situations.

This just removes those defaults. 

If there's any existing templates that are relying on this default, they'll need to be updated -- but I don't think there are, we've been adding explicit to/email parameters hopefully.