### PR TITLE
#111T Move IncrementStage action to happen AFTER other specific actions run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "0.5.0-11",
+  "version": "0.5.0-12",
   "main": "server.js",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Fixes https://github.com/openmsupply/conforma-templates/issues/111

There was 2 problems: Actions n. 3 and n. 4 that should have had the same condition were using a slight different condition, so n. 3 (generateDoc) wouldn't run and n. 4 (sendNotification) was trying to send an attached file not created on n. 3

The change on core-actions was required though since the **IncrementStage** was running before all the specific actions were running and would make an inconsistent state, as the action were checking it was a Submitted CONFORM review on Stage 3. But when it was running it should be Stage 2! Now with this change, it will correctly show that when submitting a review of Stage 2, the actions 3 and 4 that should be checking CONFORM on StageNumber = 3 will not run anymore.

This is a specific case, but pretty much the IncrementStage should be ALWAYS running after the specific actions run, so those can check the current stage before it is incremented upon on a CONFORM decision in last level of this stage.