### PR TITLE
Allow entering initialDate to generate an expiry date

### DIFF
--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -8,7 +8,15 @@ Any changes done here should also be replicated in front-end
 
 import { DateTime, Duration } from 'luxon'
 
-const generateExpiry = (duration: Duration) => DateTime.now().plus(duration).toJSDate()
+const generateExpiry = (duration: Duration, startDate?: string | Date) => {
+  const date = !startDate
+    ? DateTime.now()
+    : typeof startDate === 'string'
+    ? DateTime.fromISO(startDate)
+    : DateTime.fromJSDate(startDate)
+
+  return date.plus(duration).toJSDate()
+}
 
 // getYear() => "2022"
 // getYear("short") => "22"

--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -9,11 +9,11 @@ Any changes done here should also be replicated in front-end
 import { DateTime, Duration } from 'luxon'
 
 const generateExpiry = (duration: Duration, startDate?: string | Date) => {
-  const date = !startDate
-    ? DateTime.now()
-    : typeof startDate === 'string'
-    ? DateTime.fromISO(startDate)
-    : DateTime.fromJSDate(startDate)
+  const date = startDate
+    ? typeof startDate === 'string'
+      ? DateTime.fromISO(startDate)
+      : DateTime.fromJSDate(startDate)
+    : DateTime.now()
 
   return date.plus(duration).toJSDate()
 }


### PR DESCRIPTION
Required for issue https://github.com/openmsupply/conforma-templates/issues/113
to enable generating an expiry_date prior to creation of product - so it's based on the `statusHistoryDate` of currentStage. And that's the same one which will be used afterwards when creating the product.expiry_date on last stage approval