### PR TITLE
#997 Lookup table type inference

### DIFF
--- a/src/lookup-table/models/LookupTable.model.ts
+++ b/src/lookup-table/models/LookupTable.model.ts
@@ -159,7 +159,7 @@ const LookupTableModel = () => {
     tableName: string,
     fieldMaps: FieldMapType[]
   ): Promise<boolean> => {
-    const text = `UPDATE data_table SET field_map = $1 WHERE display_name = $2`
+    const text = `UPDATE data_table SET field_map = $1 WHERE table_name = $2`
     try {
       await DBConnect.query({ text, values: [JSON.stringify(fieldMaps), tableName] })
       return true

--- a/src/lookup-table/models/LookupTable.model.ts
+++ b/src/lookup-table/models/LookupTable.model.ts
@@ -8,6 +8,7 @@ import {
   LookupTableStructure,
 } from '../types'
 import config from '../../config'
+import { exportDataRows } from '../utils/dataTypeUtils'
 
 const { dataTablePrefix } = config
 
@@ -17,7 +18,7 @@ const LookupTableModel = () => {
     const fields = fieldMap.map(mappedField).join(',')
     const text = `SELECT ${fields} FROM ${dataTablePrefix}${tableName}`
     const result = await DBConnect.query({ text })
-    return result.rows
+    return exportDataRows(fieldMap, result.rows)
   }
 
   const createStructure = async ({ tableName, displayName, fieldMap }: LookupTableStructure) => {

--- a/src/lookup-table/services/LookupTable.service.ts
+++ b/src/lookup-table/services/LookupTable.service.ts
@@ -54,7 +54,7 @@ const LookupTableService = async (props: LookupTableServiceProps) => {
       dataType: 'serial PRIMARY KEY',
     }
 
-    // Mutates field maps and rows *in-place* with the correct Postgres data
+    // Mutate field maps and rows *in-place* with the correct Postgres data
     // types
     setDataTypes(fieldMaps, rows)
 
@@ -87,7 +87,7 @@ const LookupTableService = async (props: LookupTableServiceProps) => {
 
     const results = await compareFieldMaps()
 
-    // Mutates field maps and rows *in-place* with the correct Postgres data
+    // Mutate field maps and rows *in-place* with the correct Postgres data
     // types
     setDataTypes(fieldMaps, rows)
 

--- a/src/lookup-table/services/LookupTable.service.ts
+++ b/src/lookup-table/services/LookupTable.service.ts
@@ -1,7 +1,7 @@
 import { singular } from 'pluralize'
 import { LookupTableModel } from '../models'
 import { FieldMapType, LookupTableStructureFull } from '../types'
-import { toCamelCase, toSnakeCase } from '../utils'
+import { setDataTypes, toCamelCase, toSnakeCase } from '../utils'
 import { LookupTableHeadersValidator, LookupTableNameValidator } from '../utils/validations'
 import { ValidationErrors } from '../utils/validations/error'
 import { ILookupTableNameValidator, IValidator } from '../utils/validations/types'
@@ -53,6 +53,10 @@ const LookupTableService = async (props: LookupTableServiceProps) => {
       gqlName: 'id',
       dataType: 'serial PRIMARY KEY',
     }
+
+    // Mutates field maps and rows *in-place* with the correct Postgres data
+    // types
+    setDataTypes(fieldMaps, rows)
 
     const newTableFieldMap = [idField, ...fieldMaps]
 

--- a/src/lookup-table/services/LookupTable.service.ts
+++ b/src/lookup-table/services/LookupTable.service.ts
@@ -86,6 +86,11 @@ const LookupTableService = async (props: LookupTableServiceProps) => {
     dbFieldMap = structure.fieldMap
 
     const results = await compareFieldMaps()
+
+    // Mutates field maps and rows *in-place* with the correct Postgres data
+    // types
+    setDataTypes(fieldMaps, rows)
+
     await createNewColumns()
     await createUpdateRows()
 

--- a/src/lookup-table/utils/dataTypeUtils.ts
+++ b/src/lookup-table/utils/dataTypeUtils.ts
@@ -33,6 +33,20 @@ export const setDataTypes = (fieldMaps: FieldMapType[], rows: object[]) => {
   })
 }
 
+// Prepares table export by stringifying jsonb fields
+// Mutates rows *in-place*
+export const exportDataRows = (fieldMaps: FieldMapType[], rows: { [key: string]: any }[]) => {
+  const jsonFields = fieldMaps.filter((e) => e.dataType === 'jsonb').map((e) => e.fieldname)
+
+  rows.forEach((row) => {
+    jsonFields.forEach((jsonField: string) => {
+      row[jsonField] = row[jsonField] !== null ? JSON.stringify(row[jsonField]) : ''
+    })
+  })
+
+  return rows
+}
+
 type PostgresDataType = 'varchar' | 'boolean' | 'integer' | 'double precision' | 'jsonb'
 
 const getType = (value: string): PostgresDataType | null => {

--- a/src/lookup-table/utils/dataTypeUtils.ts
+++ b/src/lookup-table/utils/dataTypeUtils.ts
@@ -1,0 +1,78 @@
+import { mapValues } from 'lodash'
+import { FieldMapType } from '../types'
+
+export const setDataTypes = (fieldMaps: FieldMapType[], rows: object[]) => {
+  // Determine type
+  const done: string[] = []
+  for (const row of rows) {
+    Object.entries(row).forEach(([key, value], index) => {
+      if (!done.includes(key)) {
+        const type = getType(value)
+        if (type !== null) {
+          fieldMaps[index].dataType = type
+          done.push(key)
+        }
+      }
+    })
+
+    if (done.length === fieldMaps.length) break
+  }
+
+  const fieldMap: { [key: string]: any } = fieldMaps.reduce((acc, curr) => {
+    const name = curr.fieldname
+    const type = curr.dataType
+    console.log(name, type)
+    return { ...acc, [name]: type }
+  }, {})
+
+  // Now mutate rows based on those types
+  rows.forEach((row, index) => {
+    rows[index] = mapValues(row, (value, key) => {
+      return convertType(value, fieldMap[key])
+    })
+  })
+}
+
+type PostgresDataType = 'varchar' | 'boolean' | 'integer' | 'double precision' | 'jsonb'
+
+const getType = (value: string): PostgresDataType | null => {
+  if (value === '') return null
+
+  // Boolean
+  if (value.toLowerCase() === 'false' || value.toLowerCase() === 'true') return 'boolean'
+
+  // Number
+  if (!isNaN(Number(value))) {
+    // Integer or float? Check for decimal part
+    if (/^\d+\.\d+$/.test(value)) return 'double precision'
+    else return 'integer'
+  }
+
+  // TO-DO: Recognize ISO date/time strings
+
+  // JSON Data
+  try {
+    JSON.parse(value)
+    return 'jsonb'
+  } catch {}
+
+  return 'varchar'
+}
+
+const convertType = (value: string, type: PostgresDataType) => {
+  if (value === '') return null
+  switch (type) {
+    case 'varchar':
+      return value
+    case 'boolean':
+      return value.toLowerCase() === 'true'
+    case 'integer':
+      return parseInt(value)
+    case 'double precision':
+      return parseFloat(value)
+    case 'jsonb':
+      return value
+    default:
+      return value
+  }
+}

--- a/src/lookup-table/utils/dataTypeUtils.ts
+++ b/src/lookup-table/utils/dataTypeUtils.ts
@@ -21,13 +21,13 @@ export const setDataTypes = (fieldMaps: FieldMapType[], rows: object[]) => {
   const fieldMap: { [key: string]: any } = fieldMaps.reduce((acc, curr) => {
     const name = curr.fieldname
     const type = curr.dataType
-    console.log(name, type)
     return { ...acc, [name]: type }
   }, {})
 
   // Now mutate rows based on those types
   rows.forEach((row, index) => {
     rows[index] = mapValues(row, (value, key) => {
+      if (key === 'id') return value
       return convertType(value, fieldMap[key])
     })
   })

--- a/src/lookup-table/utils/dataTypeUtils.ts
+++ b/src/lookup-table/utils/dataTypeUtils.ts
@@ -79,6 +79,7 @@ const getType = (value: string): PostgresDataType | null => {
     return 'jsonb'
   } catch {}
 
+  // Default to string
   return 'varchar'
 }
 

--- a/src/lookup-table/utils/dataTypeUtils.ts
+++ b/src/lookup-table/utils/dataTypeUtils.ts
@@ -1,5 +1,6 @@
 import { mapValues } from 'lodash'
 import { FieldMapType } from '../types'
+import { DateTime } from 'luxon'
 
 export const setDataTypes = (fieldMaps: FieldMapType[], rows: object[]) => {
   // Determine type
@@ -47,7 +48,13 @@ export const exportDataRows = (fieldMaps: FieldMapType[], rows: { [key: string]:
   return rows
 }
 
-type PostgresDataType = 'varchar' | 'boolean' | 'integer' | 'double precision' | 'jsonb'
+type PostgresDataType =
+  | 'varchar'
+  | 'boolean'
+  | 'integer'
+  | 'double precision'
+  | 'jsonb'
+  | 'timestamptz'
 
 const getType = (value: string): PostgresDataType | null => {
   if (value === '') return null
@@ -62,7 +69,9 @@ const getType = (value: string): PostgresDataType | null => {
     else return 'integer'
   }
 
-  // TO-DO: Recognize ISO date/time strings
+  // Date/Time
+  const d = DateTime.fromISO(value)
+  if (d.isValid) return 'timestamptz'
 
   // JSON Data
   try {
@@ -86,6 +95,8 @@ const convertType = (value: string, type: PostgresDataType) => {
       return parseFloat(value)
     case 'jsonb':
       return value
+    case 'timestamptz':
+      return new Date(value)
     default:
       return value
   }

--- a/src/lookup-table/utils/index.ts
+++ b/src/lookup-table/utils/index.ts
@@ -1,3 +1,5 @@
+import { setDataTypes } from './dataTypeUtils'
+
 const toSnakeCase = (str: any) => {
   return (
     str &&
@@ -13,4 +15,4 @@ const toCamelCase = (text: string) => {
   return text.substr(0, 1).toLowerCase() + text.substr(1)
 }
 
-export { toSnakeCase, toCamelCase }
+export { toSnakeCase, toCamelCase, setDataTypes }


### PR DESCRIPTION
Fix #997 

Requires front-end https://github.com/openmsupply/conforma-web-app/pull/1471 in order for the UI to work with this.

Tried to be as minimally invasive to the existing code as possible, so this just intercepts the existing imported data and mutates the fieldMap and data rows in-place to conform to inferred data type. The postgres fields will be one of:
- `varchar` (what they all are by default)
- `integer`
- `double precision`
- `boolean`
- `timestamptz`
- `jsonb` (the one we really want for scraped data import)

Test it with the following.

Import this lookup table, and notice the different data types in the created table:
[test_data.csv](https://github.com/openmsupply/conforma-server/files/10424847/test_data.csv)

Then import this one over the top to see the effect of modifying the exported CSV.
[test_2023-01-16.csv](https://github.com/openmsupply/conforma-server/files/10424848/test_2023-01-16.csv)

You can export it again yourself and change/add some data to check re-import as well.
