### PR TITLE
#1004 Add new filter to remove elements in array

### DIFF
--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -8,6 +8,42 @@ Any changes done here should also be replicated in front-end
 
 import { DateTime, Duration } from 'luxon'
 
+type FilterRule = 'exclude' | 'include'
+interface FilterOptions {
+  key?: string
+  rule?: FilterRule
+  values: string | string[]
+}
+
+const filterArray = (valuesArray: Object[] | string[], options: FilterOptions) => {
+  const { key, rule = 'exclude', values } = options
+  if (
+    (valuesArray.length > 0 && key && typeof valuesArray[0] === 'object') ||
+    (!key && typeof valuesArray[0] === 'string')
+  )
+    return key
+      ? (valuesArray as Object[]).filter(
+          (
+            obj // Array of strings
+          ) =>
+            Object.entries(obj).find(
+              ([keyMap, value]) =>
+                keyMap === key &&
+                (rule === 'include' ? values.includes(value) : !values.includes(value))
+            )
+        )
+      : (valuesArray as string[]).filter(
+          (
+            str // Array of objects
+          ) => (rule === 'include' ? values.includes(str) : !values.includes(str))
+        )
+  else {
+    if (valuesArray.length > 0)
+      console.log('Type of elements in array mismatch filter options', options)
+    return valuesArray
+  }
+}
+
 const generateExpiry = (duration: Duration, startDate?: string | Date) => {
   const date = startDate
     ? typeof startDate === 'string'
@@ -65,6 +101,7 @@ const extractNumber = (input: string) => {
 const removeAccents = (input: string) => input.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
 
 export default {
+  filterArray,
   generateExpiry,
   getYear,
   getFormattedDate,

--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -25,8 +25,8 @@ const filterArray = (valuesArray: unknown[], options: FilterOptions) => {
   return valuesArray.filter((element) => {
     if (key && isObject(element))
       return Object.entries(element as Object).find(
-        ([keyMap, value]) =>
-          keyMap === key &&
+        ([objKey, value]) =>
+          objKey === key &&
           (rule === 'include' ? compareValues.includes(value) : !compareValues.includes(value))
       )
     else

--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -8,40 +8,27 @@ Any changes done here should also be replicated in front-end
 
 import { DateTime, Duration } from 'luxon'
 
-type FilterRule = 'exclude' | 'include'
 interface FilterOptions {
   key?: string
-  rule?: FilterRule
+  rule?: 'exclude' | 'include'
   values: string | string[]
 }
 
-const filterArray = (valuesArray: Object[] | string[], options: FilterOptions) => {
+const filterArray = (valuesArray: unknown[], options: FilterOptions) => {
   const { key, rule = 'exclude', values } = options
-  if (
-    (valuesArray.length > 0 && key && typeof valuesArray[0] === 'object') ||
-    (!key && typeof valuesArray[0] === 'string')
-  )
-    return key
-      ? (valuesArray as Object[]).filter(
-          (
-            obj // Array of strings
-          ) =>
-            Object.entries(obj).find(
-              ([keyMap, value]) =>
-                keyMap === key &&
-                (rule === 'include' ? values.includes(value) : !values.includes(value))
-            )
-        )
-      : (valuesArray as string[]).filter(
-          (
-            str // Array of objects
-          ) => (rule === 'include' ? values.includes(str) : !values.includes(str))
-        )
-  else {
-    if (valuesArray.length > 0)
-      console.log('Type of elements in array mismatch filter options', options)
-    return valuesArray
-  }
+  const compareValues = Array.isArray(values) ? values : [values]
+  return valuesArray.filter((element) => {
+    if (key && typeof element === 'object')
+      return Object.entries(element as Object).find(
+        ([keyMap, value]) =>
+          keyMap === key &&
+          (rule === 'include' ? compareValues.includes(value) : !compareValues.includes(value))
+      )
+    else
+      return rule === 'include'
+        ? compareValues.includes(element as string)
+        : !compareValues.includes(element as string)
+  })
 }
 
 const generateExpiry = (duration: Duration, startDate?: string | Date) => {

--- a/src/components/actions/evaluatorFunctions.ts
+++ b/src/components/actions/evaluatorFunctions.ts
@@ -16,9 +16,14 @@ interface FilterOptions {
 
 const filterArray = (valuesArray: unknown[], options: FilterOptions) => {
   const { key, rule = 'exclude', values } = options
+
   const compareValues = Array.isArray(values) ? values : [values]
+
+  const isObject = (element: unknown) =>
+    typeof element === 'object' && !Array.isArray(element) && element !== null
+
   return valuesArray.filter((element) => {
-    if (key && typeof element === 'object')
+    if (key && isObject(element))
       return Object.entries(element as Object).find(
         ([keyMap, value]) =>
           keyMap === key &&


### PR DESCRIPTION
Fixes #1004

Required a new evaluator function to remove permissions from the array returned by user-permissions, so not all of the permissions displays in specific templates. Work to be used in configuration of https://github.com/openmsupply/conforma-templates/issues/55