### PR TITLE
Add column registration on application table

### DIFF
--- a/database/buildSchema/18_application.sql
+++ b/database/buildSchema/18_application.sql
@@ -14,11 +14,11 @@ CREATE TABLE public.application (
     org_id integer REFERENCES public.organisation (id) ON DELETE CASCADE,
     session_id varchar,
     serial varchar UNIQUE,
-    registration varchar UNIQUE,
     name varchar,
     outcome public.application_outcome DEFAULT 'PENDING',
+    outcome_registration varchar UNIQUE,
     is_active bool,
     is_config bool DEFAULT FALSE,
-    TRIGGER public.trigger,
+    TRIGGER public.trigger
 );
 

--- a/database/buildSchema/18_application.sql
+++ b/database/buildSchema/18_application.sql
@@ -14,10 +14,11 @@ CREATE TABLE public.application (
     org_id integer REFERENCES public.organisation (id) ON DELETE CASCADE,
     session_id varchar,
     serial varchar UNIQUE,
+    registration varchar UNIQUE,
     name varchar,
     outcome public.application_outcome DEFAULT 'PENDING',
     is_active bool,
     is_config bool DEFAULT FALSE,
-    TRIGGER public.trigger
+    TRIGGER public.trigger,
 );
 

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -695,7 +695,7 @@ const migrateData = async () => {
     console.log(' - Add registration field to application Table')
     await DB.changeSchema(`
       ALTER TABLE public.application
-        ADD COLUMN IF NOT EXISTS registration varchar UNIQUE;
+        ADD COLUMN IF NOT EXISTS outcome_registration varchar UNIQUE;
     `)
   }
 

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -690,6 +690,15 @@ const migrateData = async () => {
     `)
   }
 
+  // v0.5.0
+  if (databaseVersionLessThan('0.5.2')) {
+    console.log(' - Add registration field to application Table')
+    await DB.changeSchema(`
+      ALTER TABLE public.application
+        ADD COLUMN IF NOT EXISTS registration varchar UNIQUE;
+    `)
+  }
+
   // Other version migrations continue here...
 
   // Update (almost all) Indexes, Views, Functions, Triggers regardless, since


### PR DESCRIPTION
Fixes #55T

Adding an extra column to `application` table since it cannot be modified using `modifyRecord` due to our own restrictions, we should always add columns in the database when application needs to be altered.

With that in place we can store the generated registration to the application record in a different stage than the one that needs to use the same registration (and add to the product).