### PR TITLE
#1016 Reload preferences after snapshot load

### DIFF
--- a/plugins/action_send_notification/src/sendNotification.ts
+++ b/plugins/action_send_notification/src/sendNotification.ts
@@ -192,7 +192,7 @@ const prepareAttachments = async (
   filesFolder: string
 ): Promise<Attachment[]> => {
   const attachmentInput = Array.isArray(attachments) ? attachments : [attachments]
-  const attachmentObjects = []
+  const attachmentObjects: Attachment[] = []
   for (const file of attachmentInput) {
     if (typeof file === 'object') {
       if (!file?.path || !file?.filename) throw new Error('Invalid attachment')

--- a/src/components/actions/getApplicationData.ts
+++ b/src/components/actions/getApplicationData.ts
@@ -73,7 +73,7 @@ export const getApplicationData = async (input: {
     appRootFolder: getAppEntryPointDir(),
     filesFolder: config.filesFolder,
     webHostUrl: process.env.WEB_HOST,
-    SMTPConfig: config.SMTPConfig,
+    SMTPConfig: config?.SMTPConfig,
   }
 
   const sectionCodes = (await DBConnect.getApplicationSections(applicationId)).map(

--- a/src/components/utilityFunctions.ts
+++ b/src/components/utilityFunctions.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import fs from 'fs'
+import fs, { readFileSync } from 'fs'
 import { camelCase, snakeCase, mapKeys } from 'lodash'
 import { singular } from 'pluralize'
 import config from '../config'

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,11 @@
 import prefs from '../preferences/preferences.json'
 require('dotenv').config()
 import { version } from '../package.json'
+import { ServerPreferences } from './types'
 const isProductionBuild = process.env.NODE_ENV === 'production'
-const serverPrefs: { [key: string]: any } = prefs.server
+const serverPrefs: ServerPreferences = prefs.server
 
-const config: { [key: string]: any } = {
+const config = {
   pg_database_connection: {
     user: 'postgres',
     host: 'localhost',

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,7 @@ export interface ActionApplicationData extends BaseApplicationData {
   environmentData: {
     appRootFolder: string
     filesFolder: string
-    SMTPConfig: {
+    SMTPConfig?: {
       host: string
       port: number
       secure: boolean
@@ -243,3 +243,37 @@ export interface Organisation {
 export interface UserOrg extends User, Organisation {
   id: number
 }
+
+export interface ServerPreferences {
+  thumbnailMaxWidth: number
+  thumbnailMaxHeight: number
+  hoursSchedule?: number[]
+  SMTPConfig?: {
+    host: string
+    port: number
+    secure: boolean
+    user: string
+    defaultFromName: string
+    defaultFromEmail: string
+  }
+  systemManagerPermissionName?: string
+  previewDocsMinKeepTime?: string
+  previewDocsCleanupSchedule?: number[]
+  backupSchedule?: number[]
+  backupFilePrefix?: string
+  maxBackupDurationDays?: number
+}
+
+export const serverPrefKeys: (keyof ServerPreferences)[] = [
+  // Must contain ALL keys of ServerPreferences -- please check
+  'thumbnailMaxHeight',
+  'thumbnailMaxWidth',
+  'hoursSchedule',
+  'SMTPConfig',
+  'systemManagerPermissionName',
+  'previewDocsMinKeepTime',
+  'previewDocsCleanupSchedule',
+  'backupSchedule',
+  'backupFilePrefix',
+  'maxBackupDurationDays',
+]


### PR DESCRIPTION
Fix #1016 

Just mutates the config object directly, which affects all "config" references throughout (since they're all using the same original object).


If you want to test, just add a `console.log(config)` somewhere and notice how it changes after loading a different snapshot (assuming its prefs are different), but doesn't change when on `develop`.