### PR TITLE
#1019 Fix template export bug

### DIFF
--- a/src/components/exportAndImport/exportToJson.ts
+++ b/src/components/exportAndImport/exportToJson.ts
@@ -18,8 +18,8 @@ const getRecordsAsObject = async ({
 
   for (const table of tablesToExport) {
     const { tableName } = table
-    const filteredReferences = getFilteredReferences(table, filteredRecords)
     const baseFilter = filters?.[tableName]
+    const filteredReferences = getFilteredReferences(table, filteredRecords, baseFilter)
 
     const { gql, getter, hasFilter } = constructGqlAndGetter(table, filteredReferences, baseFilter)
     const result = await databaseConnect.gqlQuery(gql)
@@ -33,7 +33,8 @@ const getRecordsAsObject = async ({
 
 const getFilteredReferences = (
   { referenceTables, columns }: DatabaseTable,
-  previousFilteredRecords: ObjectRecords
+  previousFilteredRecords: ObjectRecords,
+  baseFilter: object | undefined
 ) => {
   if (referenceTables.length === 0) return {}
 
@@ -45,10 +46,16 @@ const getFilteredReferences = (
   columns.forEach(
     ({
       isReference,
+      isNullable,
       reference: { tableName: referencedTableName, columnName: referencedColumnName },
       columnName,
     }) => {
       if (!isReference) return
+      // If the column is nullable and there is already a base filter defined
+      // (in options) for this table, then don't make additional filters based
+      // on references, otherwise it can filter out too much (particularly for
+      // template export)
+      if (baseFilter && isNullable) return
       const filteredRecords = previousFilteredRecords[referencedTableName]
       if (!filteredRecords) return
 
@@ -64,11 +71,9 @@ const getFilteredReferences = (
 const constructGqlAndGetter = (
   { tableName, columns }: DatabaseTable,
   filteredReferences: object,
-  baseFilter: object
+  baseFilter: object | undefined
 ) => {
-  // If filters already defined in options (baseFilter), just use that,
-  // otherwise we can end up filtering out too much
-  const filter = baseFilter ?? filteredReferences ?? {}
+  const filter = { ...baseFilter, ...filteredReferences }
   const hasFilter = Object.keys(filter).length > 0
 
   const filterString = !hasFilter ? '' : `(filter: ${noQuoteKeyStringify(filter)})`

--- a/src/components/exportAndImport/getDatabaseInfo.ts
+++ b/src/components/exportAndImport/getDatabaseInfo.ts
@@ -15,6 +15,7 @@ const getDatabaseInfo = async () => {
       table_name,
       table_type,
       column_name,
+      is_nullable,
       is_generated,
       data_type,
       sub_data_type,
@@ -38,6 +39,7 @@ const getDatabaseInfo = async () => {
       const isPrimary = constraint_type === 'PRIMARY KEY'
       const isUnique = constraint_type === 'UNIQUE'
       const isReference = constraint_type === 'FOREIGN KEY'
+      const isNullable = is_nullable === 'YES'
       const isGenerated = is_generated === 'ALWAYS'
       const isEnum = data_type === 'USER-DEFINED'
       const isJson = data_type === 'jsonb'
@@ -50,6 +52,7 @@ const getDatabaseInfo = async () => {
         columnName,
         isPrimary,
         isUnique,
+        isNullable,
         isGenerated,
         isReference,
         isEnum,

--- a/src/components/exportAndImport/types.ts
+++ b/src/components/exportAndImport/types.ts
@@ -2,6 +2,7 @@ export type DatabaseColumn = {
   columnName: string
   isPrimary: boolean
   isUnique: boolean
+  isNullable: boolean
   isGenerated: boolean
   isReference: boolean
   isEnum: boolean


### PR DESCRIPTION
Fixes #1019 

Took a while to figure out what was going on here -- bit of a rabbit hole to go down.

The problem was in the way the filter references are generated in `exportToJson.ts` -- because the "template" table has a reference to "templateCategory", a template filter would be generated restricting it to templateCategory ids already found when accessing templateCategory records. But there would be no templateCategory records, cos they had already been restricted by templateID (and in this case the templateCategoryId for the template is `null`) -- so it was a bit circular, and ended up putting a filter like this on template records:
```
{ templateCategoryId: { in: [] }, id: { equalTo: 98 } }
```

The template export query injects a bunch of filters into the `options` object already (from front-end query):
```
 {
      template: { id: equalToTemplateId },
      filter: { templateFilterJoins: allElementsMatchTemplateId },
      permissionName: { templatePermissions: allElementsMatchTemplateId },
      templateCategory: { templates: { some: { id: { equalTo: id } } } },
    }
```
So it's not necessary to additionally filter based on referenced columns.

So my fix here just uses *either* the baseFilter (as above) *or* the generated reference filters, not a merge of both like it previously did. As far as I can tell the baseFilter is always a complete superset of the reference filters (at least it is for template export), which in itself makes the reference filters redundant for those tables.