### PR TITLE
1018 Fix for new columns with `null` values

### DIFF
--- a/plugins/action_modify_record/src/modifyRecord.ts
+++ b/plugins/action_modify_record/src/modifyRecord.ts
@@ -25,16 +25,16 @@ const modifyRecord: ActionPluginType = async ({ parameters, applicationData, DBC
   const valueToMatch = matchValue ?? record[fieldToMatch]
   const applicationId = applicationData?.applicationId || 0
 
-  // Don't update fields with NULL
-  for (const key in record) {
-    if (record[key] === null || record[key] === undefined) delete record[key]
-  }
-
   // Build full record
   const fullRecord = objectKeysToSnakeCase({
     ...record,
     ...mapValues(data, (property) => get(applicationData, property, null)),
   })
+
+  // Don't update fields with NULL
+  for (const key in fullRecord) {
+    if (fullRecord[key] === null || fullRecord[key] === undefined) delete fullRecord[key]
+  }
 
   try {
     await createOrUpdateTable(DBConnect, db, tableNameProper, fullRecord, tableName)


### PR DESCRIPTION
Fix #1018 

Just a problem with the ordering of events -- it was doing the `null` check before the full record had been created, which is why it worked in some cases but not others.

Seems good now.