### PR TITLE
#137T Add username authorisation check

### DIFF
--- a/src/components/permissions/loginHelpers.ts
+++ b/src/components/permissions/loginHelpers.ts
@@ -78,6 +78,7 @@ const getUserInfo = async (userOrgParameters: UserOrgParameters) => {
     templatePermissions: buildTemplatePermissions(templatePermissionRows),
     JWT: await getSignedJWT({
       userId: userId || newUserId,
+      username: username || newUsername,
       orgId,
       templatePermissionRows,
       sessionId: returnSessionId,

--- a/src/components/permissions/rowLevelPolicyHelpers.ts
+++ b/src/components/permissions/rowLevelPolicyHelpers.ts
@@ -31,9 +31,9 @@ export const baseJWT = { aud: 'postgraphile' }
   }
 */
 const compileJWT = (JWTelements: any) => {
-  const { userId, orgId, templatePermissionRows, sessionId, isAdmin } = JWTelements
+  const { userId, orgId, username, templatePermissionRows, sessionId, isAdmin } = JWTelements
 
-  let JWT: any = { ...baseJWT, userId, orgId, sessionId, isAdmin }
+  let JWT: any = { ...baseJWT, userId, orgId, username, sessionId, isAdmin }
   const templateIdsForPolicy: { [policyAbbreviation: string]: number[] } = {}
 
   templatePermissionRows.forEach((permissionRow: PermissionRow) => {


### PR DESCRIPTION
This prevents a potential privacy problem as outlined in the [templates repo #137](https://github.com/openmsupply/conforma-templates/issues/137).

The username is now included in the JWT token data. And so we can compare the token username to the user data fetched when loading (based on userID). And if they don't match, we don't allow fetching any user data, and the front-end will be logged out.

**To test**:
- On `develop`, log in as userID 100 (ext1) on PNG snapshot. Then (from another browser), load the Fiji snapshot. Then refresh the original browser. You'll now be logged in as a different person (with ID 100).
- Switch to this branch, then repeat the above procedure. You should be logged out when refreshing.