### PR TITLE
#1036 #1035 applicationData fix and additional migration

### DIFF
--- a/database/buildSchema/24_action_queue.sql
+++ b/database/buildSchema/24_action_queue.sql
@@ -9,7 +9,7 @@ CREATE TYPE public.action_queue_status AS ENUM (
 
 CREATE TABLE public.action_queue (
     id serial PRIMARY KEY,
-    trigger_event integer REFERENCES public.trigger_queue (id),
+    trigger_event integer REFERENCES public.trigger_queue (id) ON DELETE CASCADE,
     trigger_payload jsonb,
     template_id integer REFERENCES public.template (id) ON DELETE CASCADE,
     sequence integer

--- a/database/migration/databaseMethods.ts
+++ b/database/migration/databaseMethods.ts
@@ -118,9 +118,8 @@ const databaseMethods = {
       console.log(err.message)
     }
   },
-  populateTriggerQueueApplicationId: async () => {
-    const trigger_count = (await DBConnect.query({ text: `SELECT MAX(id) FROM trigger_queue;` }))
-      .rows[0].max
+  populateQueueApplicationIds: async (tableName: 'trigger_queue' | 'action_queue') => {
+    const count = (await DBConnect.query({ text: `SELECT MAX(id) FROM ${tableName};` })).rows[0].max
 
     // This is duplicated in the later functions script, but we need it here
     // now, otherwise there'll be no application_id data in the review table.
@@ -132,70 +131,36 @@ const databaseMethods = {
       `,
     })
 
-    for (let id = 1; id <= trigger_count; id++) {
-      const trigger_record = (
-        await DBConnect.query({
-          text: 'SELECT "table", record_id FROM trigger_queue WHERE id = $1',
-          values: [id],
-        })
-      ).rows[0]
+    for (let id = 1; id <= count; id++) {
+      const trigger_data =
+        tableName === 'trigger_queue'
+          ? (
+              await DBConnect.query({
+                text: 'SELECT "table", record_id FROM trigger_queue WHERE id = $1',
+                values: [id],
+              })
+            ).rows[0]
+          : (
+              await DBConnect.query({
+                text: 'SELECT trigger_payload FROM action_queue WHERE id = $1',
+                values: [id],
+              })
+            ).rows[0]?.trigger_payload
 
-      if (!trigger_record) continue
+      if (!trigger_data) continue
 
-      const { table, record_id } = trigger_record
-
-      try {
-        const application_id = await DBConnect.getApplicationIdFromTrigger(table, record_id)
-        await DBConnect.query({
-          text: 'UPDATE trigger_queue SET application_id = $1 WHERE id = $2',
-          values: [application_id, id],
-        })
-      } catch {
-        // Application no longer exists, so delete the trigger_queue record
-        await DBConnect.query({
-          text: 'DELETE FROM trigger_queue WHERE id = $1',
-          values: [id],
-        })
-      }
-    }
-  },
-  populateActionQueueApplicationId: async () => {
-    const action_count = (await DBConnect.query({ text: 'SELECT MAX(id) FROM action_queue;' }))
-      .rows[0].max
-
-    // This is duplicated in the later functions script, but we need it here
-    // now, otherwise there'll be no application_id data in the review table.
-    await DBConnect.query({
-      text: `
-      ALTER TABLE public.review
-        DROP COLUMN IF EXISTS application_id CASCADE,
-        ADD COLUMN IF NOT EXISTS application_id integer GENERATED ALWAYS AS (public.review_application_id (review_assignment_id)) STORED REFERENCES public.application (id) ON DELETE CASCADE;
-      `,
-    })
-
-    for (let id = 1; id <= action_count; id++) {
-      const trigger_payload = (
-        await DBConnect.query({
-          text: 'SELECT trigger_payload FROM action_queue WHERE id = $1',
-          values: [id],
-        })
-      ).rows[0]?.trigger_payload
-
-      if (!trigger_payload) continue
-
-      const { table, record_id } = trigger_payload
+      const { table, record_id } = trigger_data
 
       try {
         const application_id = await DBConnect.getApplicationIdFromTrigger(table, record_id)
-
         await DBConnect.query({
-          text: 'UPDATE action_queue SET application_id = $1 WHERE id = $2',
+          text: `UPDATE ${tableName} SET application_id = $1 WHERE id = $2`,
           values: [application_id, id],
         })
       } catch {
-        // Application no longer exists, so delete the action_queue record
+        // Application no longer exists, so delete the queue record
         await DBConnect.query({
-          text: 'DELETE FROM action_queue WHERE id = $1',
+          text: `DELETE FROM ${tableName} WHERE id = $1`,
           values: [id],
         })
       }

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -741,7 +741,7 @@ const migrateData = async () => {
         REFERENCES public.application (id) ON DELETE CASCADE;
       `)
       console.log(' ...and updating trigger_queue data')
-      await DB.populateTriggerQueueApplicationId()
+      await DB.populateQueueApplicationIds('trigger_queue')
     }
     if (!(await DB.checkColumnExists('action_queue', 'application_id'))) {
       await DB.changeSchema(`
@@ -750,9 +750,8 @@ const migrateData = async () => {
         REFERENCES public.application (id) ON DELETE CASCADE;
       `)
       console.log(' ...and updating action_queue data')
-      await DB.populateActionQueueApplicationId()
+      await DB.populateQueueApplicationIds('action_queue')
     }
-    // await DB.populateActionQueueApplicationId()
   }
 
   // Other version migrations continue here...

--- a/database/migration/migrateData.ts
+++ b/database/migration/migrateData.ts
@@ -723,6 +723,38 @@ const migrateData = async () => {
     `)
   }
 
+  // v0.6.0
+  if (databaseVersionLessThan('0.6.0')) {
+    console.log(' - Update FK reference to trigger_queue in action_queue')
+    await DB.changeSchema(`
+      ALTER TABLE action_queue DROP CONSTRAINT IF EXISTS   
+        action_queue_trigger_event_fkey; 
+      ALTER TABLE action_queue ADD CONSTRAINT action_queue_trigger_event_fkey
+        FOREIGN KEY (trigger_event) REFERENCES trigger_queue (id) ON DELETE CASCADE;
+    `)
+
+    console.log(' - Add application_id column to trigger_queue & action_queue')
+    if (!(await DB.checkColumnExists('trigger_queue', 'application_id'))) {
+      await DB.changeSchema(`
+      ALTER TABLE public.trigger_queue
+        ADD COLUMN IF NOT EXISTS application_id INTEGER
+        REFERENCES public.application (id) ON DELETE CASCADE;
+      `)
+      console.log(' ...and updating trigger_queue data')
+      await DB.populateTriggerQueueApplicationId()
+    }
+    if (!(await DB.checkColumnExists('action_queue', 'application_id'))) {
+      await DB.changeSchema(`
+      ALTER TABLE public.action_queue
+        ADD COLUMN IF NOT EXISTS application_id INTEGER
+        REFERENCES public.application (id) ON DELETE CASCADE;
+      `)
+      console.log(' ...and updating action_queue data')
+      await DB.populateActionQueueApplicationId()
+    }
+    // await DB.populateActionQueueApplicationId()
+  }
+
   // Other version migrations continue here...
 
   // Update (almost all) Indexes, Views, Functions, Triggers regardless, since

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-server",
-  "version": "0.5.6-15",
+  "version": "0.5.6-19",
   "main": "server.js",
   "license": "MIT",
   "repository": {

--- a/src/components/actions/getApplicationData.ts
+++ b/src/components/actions/getApplicationData.ts
@@ -27,7 +27,7 @@ export const getApplicationData = async (input: {
   if (!applicationData) throw new Error("Can't get application data")
 
   const {
-    user: { firstName, lastName, organisation, username, dateOfBirth, email, permissionNames },
+    user: { firstName, lastName, username, dateOfBirth, email, permissionNames },
   } = await getUserInfo({
     userId: applicationData.userId,
     orgId: applicationData?.orgId || undefined,
@@ -36,8 +36,10 @@ export const getApplicationData = async (input: {
   const userData = {
     firstName,
     lastName,
-    orgName: organisation?.orgName || null,
-    orgId: organisation?.orgId || null,
+    // Org data needs to come from application info (not "getUserInfo") as user
+    // may no longer belong to the organisation that applied as.
+    orgName: await DBConnect.getOrgName(applicationData?.orgId),
+    orgId: applicationData?.orgId || null,
     username,
     dateOfBirth,
     email,

--- a/src/components/actions/processTrigger.ts
+++ b/src/components/actions/processTrigger.ts
@@ -14,7 +14,8 @@ export async function processTrigger(payload: TriggerPayload): Promise<ActionRes
   const { trigger_id, trigger, table, record_id, data, event_code, applicationDataOverride } =
     payload
 
-  const templateId = await DBConnect.getTemplateIdFromTrigger(payload.table, payload.record_id)
+  const templateId = await DBConnect.getTemplateIdFromTrigger(table, record_id)
+  const applicationId = await DBConnect.getApplicationIdFromTrigger(table, record_id)
 
   // Get Actions from matching Template (and match templateActionCode if applicable)
   const actions = (await DBConnect.getActionsByTemplateId(templateId, trigger))
@@ -40,6 +41,7 @@ export async function processTrigger(payload: TriggerPayload): Promise<ActionRes
       trigger_event: trigger_id,
       trigger_payload: payload,
       template_id: templateId,
+      application_id: applicationId,
       sequence: action.sequence,
       action_code: action.code,
       parameter_queries: action.parameter_queries,
@@ -54,6 +56,7 @@ export async function processTrigger(payload: TriggerPayload): Promise<ActionRes
   if (trigger_id)
     await DBConnect.updateTriggerQueueStatus({
       status: TriggerQueueStatus.ActionsDispatched,
+      application_id: applicationId,
       id: trigger_id,
     })
 

--- a/src/components/databaseConnect.ts
+++ b/src/components/databaseConnect.ts
@@ -124,6 +124,8 @@ class DBConnect {
 
   public addNewReviewStatusHistory = PostgresDB.addNewReviewStatusHistory
 
+  public getOrgName = PostgresDB.getOrgName
+
   public getUserData = PostgresDB.getUserData
 
   public getUserOrgData = PostgresDB.getUserOrgData

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -594,13 +594,19 @@ class PostgresDB {
     }
   }
 
-  public updateTriggerQueueStatus = async (
-    payload: TriggerQueueUpdatePayload
-  ): Promise<boolean> => {
-    const text = 'UPDATE trigger_queue SET status = $1 WHERE id = $2'
-    // TODO: Dynamically select what is being updated
+  public updateTriggerQueueStatus = async ({
+    id,
+    application_id,
+    status,
+  }: TriggerQueueUpdatePayload): Promise<boolean> => {
+    const text = `UPDATE trigger_queue SET status = $1${
+      application_id ? ', application_id = $3' : ''
+    } WHERE id = $2`
+    const values = [status, id]
+    if (application_id) values.push(application_id)
+
     try {
-      await this.query({ text, values: Object.values(payload) })
+      await this.query({ text, values })
       return true
     } catch (err) {
       throw err

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -692,7 +692,19 @@ class PostgresDB {
     }
   }
 
-  // Remove all user
+  public getOrgName = async (orgId: number | null) => {
+    if (!orgId) return null
+    const text = `
+      SELECT name FROM organisation
+      WHERE id = $1
+    `
+    try {
+      const result = await this.query({ text, values: [orgId] })
+      return result.rows[0].name
+    } catch (err) {
+      throw err
+    }
+  }
 
   // Used by triggers/actions -- please don't modify
   public getUserData = async (userId: number, orgId: number) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface ActionQueuePayload {
   trigger_event: number | null
   trigger_payload: TriggerPayload
   template_id: number
+  application_id: number
   action_code: string
   sequence: number | null
   condition_expression: EvaluatorNode
@@ -216,6 +217,7 @@ export interface TriggerPayload {
 
 export interface TriggerQueueUpdatePayload {
   id: number
+  application_id?: number
   status: TriggerQueueStatus
 }
 


### PR DESCRIPTION
Fix #1035 and #1036

The migration to add "application_id" column is a bit gnarly, but it's worth it to have this in there -- it also means actions and triggers that no longer have an associated application will automatically get deleted.

### To test

**For #1035**:
- Load various snapshots, and check that after loading/migration, the `trigger_queue` and `action_queue` tables have a populated `application_id` field.
- Try doing a few things that cause triggers (start/submit/assign etc) and check that the actions behave as normal and that they get `application_id` stored in the action and trigger queues

**For #1036**:
- Find a submitted application, then remove the applicant from the organisation they applied on behalf of. Then run the `getApplicationData` endpoint -- you should still get the correct organisation (id and name) data for the application (if you do the same thing on `develop`, the orgId and orgName fields will be `null`)

