### PR TITLE
#1028 (precursor) preferences endpoints

### DIFF
--- a/documentation/API.md
+++ b/documentation/API.md
@@ -610,3 +610,12 @@ See [Snapshot documentation](Snapshots.md) for more info
 - GET: `/lookup-table/export`
 
 See [Lookup table documentation](https://github.com/openmsupply/conforma-web-app/wiki/Lookup-Tables) for more info
+
+#### Preference management endpoints
+
+- GET: `/get-all-prefs`
+- POST: `/set-prefs`
+
+The difference between these and the public `get-prefs` endpoint is that these read and write both web app *and* server preferences, whereas the public `get-prefs` is just for the web app.
+
+See [Preferences documentation](Preferences.md) for more info

--- a/documentation/API.md
+++ b/documentation/API.md
@@ -41,6 +41,7 @@ The back-end currently has two server instances which are launched to handle inc
       - [Manage localisations](#manage-localisations)
       - [Snapshot endpoints](#snapshot-endpoints)
       - [Lookup table endpoints](#lookup-table-endpoints)
+      - [Preferences management endpoints](#preference-management-endpoints)
 
 <!-- tocstop -->
 
@@ -616,6 +617,6 @@ See [Lookup table documentation](https://github.com/openmsupply/conforma-web-app
 - GET: `/get-all-prefs`
 - POST: `/set-prefs`
 
-The difference between these and the public `get-prefs` endpoint is that these read and write both web app *and* server preferences, whereas the public `get-prefs` is just for the web app.
+The difference between these and the [public `get-prefs` endpoint](#get-preferences-endpoint) is that these read and write both web app *and* server preferences, whereas the public `get-prefs` is just for the web app.
 
 See [Preferences documentation](Preferences.md) for more info

--- a/documentation/Preferences.md
+++ b/documentation/Preferences.md
@@ -1,0 +1,41 @@
+System preferences for a given system are stored in `/preferences/preferences.json` and are exported and imported as part of a system [snapshot](Snapshots.md)
+
+They are divided into **web** and **server** blocks, which refer to the web app (front-end) and server respectively.
+
+The available properties are as follows (almost  are optional, as the system has fallback defaults for most of them, specified below):
+
+### Server
+- `thumbnailMaxWidth`: the maximum width (in pixels) of thumbnails that are generated for images uploaded with the [File Upload](API.md/#file-upload-endpoint) endpoint. (Default `300`)
+- **`thumbnailMaxHeight`**: Same as `thumbnailMaxWidth`, but for thumbnail height.
+- **`hoursSchedule`**: A schedule for how often scheduled actions should run, expressed in [node-schedule](https://www.npmjs.com/package/node-schedule) "hours" format (an array of numbers between 0 and 23, representing the hours at which the should should run). (Default: every hour)
+- **`SMTPConfig`**: Configuration options for sending emails from the system using the [sendNotification action](List-of-Action-plugins.md/#send-notification), with the following properties:  
+  ```ts
+  {
+    host: string
+    port: number
+    secure: boolean
+    user: string
+    defaultFromName: string // Can be over-ridden for specific actions
+    defaultFromEmail: string // Can be over-ridden for specific actions
+  }
+  ```
+  The default is no configuration -- no emails will be sent.  
+  Note: the **password** is not stored here, for security reasons. It must be passed in to the server as and environment variable: `SMTP_PASSWORD`. This should be in an `.env` file for development, or as part of the server start-up command for a live server.
+- **`systemManagerPermissionName`**: The "system manager" is a special permission that has certain system management rights (but not as extensive as "Admin"). Any existing permission name can be used for this special permission, in which case it should be specified here. (Default: `systemManager`)
+- **`previewDocsMinKeepTime`**: Documents generated as part of the Preview functionality will be periodically cleaned up, as they have no lasting use. It should be a Postgres duration string. The default is "2 hours".
+- **`previewDocsCleanupSchedule`**: The schedule for cleaning up (deleting) the preview documents, in node-schedule "hours" format, as above. (Default: once per day at 1 am)
+- **`backupSchedule`**: How often system backups should run, as per the node-schedule "hours" schedule above. (Default: once per day at 1 am)
+- **`backupFilePrefix`**: System backups are saved with the name format `backupFilePrefix_date_time.zip`, e.g. `conforma_backup_2023-04-04_01-00-00.zip`. (Default: "conforma_backup")
+- **`maxBackupDurationDays`**: Backups are kept for this many days, after which they're deleted next time the backup schedule runs. The default is nothing -- all backups will be kept.
+- **`testingEmail`**: During development and on a testing server, we don't want emails being sent to real people. If this property is set, and the site is not running on the designated host (as defined in `siteHost` below), then all emails will be send to this address instead. (If no `testingEmail` is specified, no emails will be sent at all)
+
+### Web app
+
+- **`paginationPresets`**: An array of integers representing options for the "number per page" dropdown on tables (Application list, Data views). (Default: `[2, 5, 10, 20, 50]`)
+- **`paginationDefault`**: How many records to show in a table by default. (Default: `20`)
+- **`defaultLanguageCode`**: If no language has been selected by the user yet, the system will default to this language. Must correspond to the `code` value specified in one of the active languages (in `localisation`) (No default, as we can't guarantee that any particular language will be active)
+- **`brandLogoFileId`**: To override the default Conforma logo on the Login page, specify the database fileId of the image file.
+- **`brandLogoOnDarkFileId`**: The same as above, but for the logo shown on the main header of the app.
+- **`defaultListFilters`**: In the Application List, these filter options will be initially enabled (though with no values selected). (Default: `['applicantDeadline', 'reviewers', 'reviewerAction', 'stage' ]`)
+- **`style`**: A limited range of CSS overrides. Currently only `headerBgColor` is supported (which changes the color of the app's main header)
+- **`siteHost`**: The canonical host domain that the live version of the site will be served from. This is how the system can determine if it is a "live" or "testing" site -- by comparing this value against the current url. If not specified, the system will be treated like a "live" system regardless of where it's actually running.

--- a/src/components/files/createThumbnails.ts
+++ b/src/components/files/createThumbnails.ts
@@ -1,7 +1,11 @@
 import config from '../../config'
 import path from 'path'
 import sharp from 'sharp'
-const { thumbnailMaxWidth, thumbnailMaxHeight } = config
+import { DEFAULT_THUMBNAIL_MAX_WIDTH, DEFAULT_THUMBNAIL_MAX_HEIGHT } from '../../constants'
+const {
+  thumbnailMaxWidth = DEFAULT_THUMBNAIL_MAX_WIDTH,
+  thumbnailMaxHeight = DEFAULT_THUMBNAIL_MAX_HEIGHT,
+} = config
 const { genericThumbnailsFolderName } = config
 
 // Maps file types (mimetype or ext) to generic

--- a/src/components/permissions/index.ts
+++ b/src/components/permissions/index.ts
@@ -5,7 +5,6 @@ import {
   routeUpdateRowPolicies,
   routeCreateHash,
   routeVerification,
-  routeGetPrefs,
   routecheckUnique,
   routeUserPermissions,
 } from './routes'
@@ -17,7 +16,6 @@ export {
   routeLoginOrg,
   routeUpdateRowPolicies,
   routeVerification,
-  routeGetPrefs,
   routecheckUnique,
-  routeUserPermissions
+  routeUserPermissions,
 }

--- a/src/components/permissions/routes.ts
+++ b/src/components/permissions/routes.ts
@@ -4,11 +4,7 @@ import { updateRowPolicies } from './rowLevelPolicyHelpers'
 import bcrypt from 'bcrypt'
 import { UserOrg } from '../../types'
 import { PermissionDetails } from '../permissions/types'
-import path from 'path'
-import { readFileSync } from 'fs'
 import { startCase } from 'lodash'
-import { getAppEntryPointDir } from '../utilityFunctions'
-import { readLanguageOptions } from '../localisation/routes'
 
 const saltRounds = 10 // For bcrypt salting: 2^saltRounds = 1024
 
@@ -207,16 +203,6 @@ const routeVerification = async (request: any, reply: any) => {
   }
 }
 
-// Serve prefs to front-end
-const routeGetPrefs = async (request: any, reply: any) => {
-  const prefs = JSON.parse(
-    readFileSync(path.join(getAppEntryPointDir(), '../preferences/preferences.json'), 'utf8')
-  )
-  const languageOptions = readLanguageOptions()
-  const latestSnapshot = await databaseConnect.getLatestSnapshotName()
-  reply.send({ preferences: prefs.web, languageOptions, latestSnapshot })
-}
-
 // Unique name/email/organisation/other check
 const routecheckUnique = async (request: any, reply: any) => {
   const { type, value, table, field, caseInsensitive } = request.query
@@ -277,6 +263,5 @@ export {
   routeUpdateRowPolicies,
   routeCreateHash,
   routeVerification,
-  routeGetPrefs,
   routecheckUnique,
 }

--- a/src/components/preferences/index.ts
+++ b/src/components/preferences/index.ts
@@ -1,0 +1,1 @@
+export * from './routes'

--- a/src/components/preferences/routes.ts
+++ b/src/components/preferences/routes.ts
@@ -1,0 +1,59 @@
+import path from 'path'
+import { readFileSync, writeFile } from 'fs'
+import { promisify } from 'util'
+import databaseConnect from '../databaseConnect'
+import {
+  getAppEntryPointDir,
+  combineRequestParams,
+  isObject,
+} from '../../components/utilityFunctions'
+import config from '../../config'
+import { PREFERENCES_FILE } from '../../constants'
+import { refreshPreferences } from '../snapshots/useSnapshot'
+import { readLanguageOptions } from '../localisation/routes'
+
+const { localisationsFolder } = config
+
+const writeFilePromise = promisify(writeFile)
+
+export type LanguageOption = {
+  languageName: string
+  description: string
+  code: string
+  locale?: string
+  flag: string // To-do: limit to flag emojis
+  enabled: boolean
+}
+
+const loadCurrentPrefs = () =>
+  JSON.parse(
+    readFileSync(path.join(getAppEntryPointDir(), '../preferences/preferences.json'), 'utf8')
+  )
+
+// Serve prefs to front-end
+export const routeGetPrefs = async (request: any, reply: any) => {
+  const prefs = loadCurrentPrefs()
+  const languageOptions = readLanguageOptions
+  const latestSnapshot = await databaseConnect.getLatestSnapshotName()
+  reply.send({ preferences: prefs.web, languageOptions, latestSnapshot })
+}
+
+// Return all prefs for editing (Admin only)
+export const routeGetAllPrefs = async (request: any, reply: any) => {
+  const preferences = loadCurrentPrefs()
+  reply.send({ ...preferences })
+}
+
+export const routeSetPrefs = async (request: any, reply: any) => {
+  const { server, web } = combineRequestParams(request)
+
+  if (!isObject(server))
+    return reply.send({ success: false, message: 'Invalid or missing Server prefs' })
+  if (!isObject(web)) return reply.send({ success: false, message: 'Invalid or missing Web prefs' })
+
+  await writeFilePromise(PREFERENCES_FILE, JSON.stringify({ server, web }, null, 2))
+
+  refreshPreferences(config)
+
+  return reply.send({ success: true, preferences: { server, web }, config })
+}

--- a/src/components/preferences/routes.ts
+++ b/src/components/preferences/routes.ts
@@ -33,7 +33,7 @@ const loadCurrentPrefs = () =>
 // Serve prefs to front-end
 export const routeGetPrefs = async (request: any, reply: any) => {
   const prefs = loadCurrentPrefs()
-  const languageOptions = readLanguageOptions
+  const languageOptions = readLanguageOptions()
   const latestSnapshot = await databaseConnect.getLatestSnapshotName()
   reply.send({ preferences: prefs.web, languageOptions, latestSnapshot })
 }

--- a/src/components/snapshots/useSnapshot.ts
+++ b/src/components/snapshots/useSnapshot.ts
@@ -286,6 +286,7 @@ const copyFiles = async (snapshotFolder: string, fileRecords: ObjectRecord[] = [
 // Mutate the active config object to inject new preferences
 type Config = typeof config
 export const refreshPreferences = (config: Config) => {
+  console.log('Refreshing configuration...')
   const serverPrefs: ServerPreferences = JSON.parse(readFileSync(PREFERENCES_FILE, 'utf-8')).server
   serverPrefKeys.forEach((key) => {
     if (serverPrefs[key]) {

--- a/src/components/utilityFunctions.ts
+++ b/src/components/utilityFunctions.ts
@@ -12,6 +12,10 @@ export function getAppEntryPointDir() {
   return path.dirname(__dirname)
 }
 
+// Returns true if input is a "proper" object (i.e. not an array or null)
+export const isObject = (element: unknown) =>
+  typeof element === 'object' && !Array.isArray(element) && element !== null
+
 // Convert object keys to camelCase
 export const objectKeysToCamelCase = (obj: { [key: string]: any }) =>
   mapKeys(obj, (_, key) => camelCase(key))

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,9 @@ export const PG_DIFF_CONFIG_FILE_NAME = 'pg-diff-config'
 export const PG_SCHEMA_DIFF_FILE_NAME = 'schema_diff'
 export const PREFERENCES_FILE_NAME = config.preferencesFileName
 
+export const DEFAULT_THUMBNAIL_MAX_WIDTH = 300
+export const DEFAULT_THUMBNAIL_MAX_HEIGHT = 300
+
 export const ROOT_FOLDER = path.join(getAppEntryPointDir(), '../')
 export const DATABASE_FOLDER = path.join(getAppEntryPointDir(), config.databaseFolder)
 export const SNAPSHOT_FOLDER = path.join(DATABASE_FOLDER, SNAPSHOT_SUBFOLDER)

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,9 +12,9 @@ import {
   routeUpdateRowPolicies,
   routeCreateHash,
   routeVerification,
-  routeGetPrefs,
   routecheckUnique,
 } from './components/permissions'
+import { routeGetPrefs, routeGetAllPrefs, routeSetPrefs } from './components/preferences'
 import {
   routeDataViews,
   routeDataViewTable,
@@ -130,6 +130,8 @@ const startServer = async () => {
         server.post('/install-language', routeInstallLanguage)
         server.post('/remove-language', routeRemoveLanguage)
         server.get('/all-languages', routeGetAllLanguageFiles)
+        server.get('/get-all-prefs', routeGetAllPrefs)
+        server.post('/set-prefs', routeSetPrefs)
         // Dev only actions -- never call from app
         server.post('/run-action', routeRunAction)
         server.post('/test-trigger', routeTestTrigger)

--- a/src/types.ts
+++ b/src/types.ts
@@ -245,8 +245,8 @@ export interface UserOrg extends User, Organisation {
 }
 
 export interface ServerPreferences {
-  thumbnailMaxWidth: number
-  thumbnailMaxHeight: number
+  thumbnailMaxWidth?: number
+  thumbnailMaxHeight?: number
   hoursSchedule?: number[]
   SMTPConfig?: {
     host: string


### PR DESCRIPTION
In order to do #1028 properly, we need to have a UI to edit the preferences. This PR just provides a couple of additional Admin endpoints (`get-all-prefs`, `set-prefs`) to facilitate this.

Front-end PR https://github.com/openmsupply/conforma-web-app/pull/1497

Documentation for all preferences included here too.