### PR TITLE
#816 Allow manager to access lookup tables

### DIFF
--- a/documentation/API.md
+++ b/documentation/API.md
@@ -472,6 +472,15 @@ It works by finding an event in the `trigger_schedule` table with matching `appl
 }
 ```
 
+#### Lookup table endpoints
+
+- POST: `/lookup-table/import`
+- GET: `/lookup-table/export`
+
+Require either "admin" or "systemManger" permissions.
+
+See [Lookup table documentation](https://github.com/openmsupply/conforma-web-app/wiki/Lookup-Tables) for more info
+
 ---
 
 ### Admin only endpoints
@@ -604,9 +613,3 @@ See [Localisation documentation](https://github.com/openmsupply/conforma-web-app
 
 See [Snapshot documentation](Snapshots.md) for more info
 
-#### Lookup table endpoints
-
-- POST: `/lookup-table/import`
-- GET: `/lookup-table/export`
-
-See [Lookup table documentation](https://github.com/openmsupply/conforma-web-app/wiki/Lookup-Tables) for more info

--- a/src/components/databaseConnect.ts
+++ b/src/components/databaseConnect.ts
@@ -140,6 +140,8 @@ class DBConnect {
 
   public getTemplatePermissions = PostgresDB.getTemplatePermissions
 
+  public getUserAdminStatus = PostgresDB.getUserAdminStatus
+
   public getAllGeneratedRowPolicies = PostgresDB.getAllGeneratedRowPolicies
 
   public getUserOrgPermissionNames = PostgresDB.getUserOrgPermissionNames

--- a/src/components/permissions/loginHelpers.ts
+++ b/src/components/permissions/loginHelpers.ts
@@ -68,11 +68,14 @@ const getUserInfo = async (userOrgParameters: UserOrgParameters) => {
 
   const returnSessionId = sessionId ?? nanoid(16)
 
-  const isAdmin = !!templatePermissionRows.find((row) => !!row?.isAdmin)
-
   const managementPrefName =
     config?.systemManagerPermissionName || config.defaultSystemManagerPermissionName
-  const isManager = !!templatePermissionRows.includes(managementPrefName)
+
+  const { isAdmin, isManager } = await databaseConnect.getUserAdminStatus(
+    managementPrefName,
+    newUserId,
+    orgId ?? null
+  )
 
   return {
     templatePermissions: buildTemplatePermissions(templatePermissionRows),

--- a/src/components/permissions/rowLevelPolicyHelpers.ts
+++ b/src/components/permissions/rowLevelPolicyHelpers.ts
@@ -7,7 +7,7 @@ import { permissionPolicyColumns } from '../postgresConnect'
 
 export const baseJWT = { aud: 'postgraphile' }
 
-/* Compiles JWT from userInfo and PerissionRows
+/* Compiles JWT from userInfo and PermissionRows
   in { userId: 1, ... }, [
   {
     templatePermissionRestrictions: {
@@ -31,9 +31,10 @@ export const baseJWT = { aud: 'postgraphile' }
   }
 */
 const compileJWT = (JWTelements: any) => {
-  const { userId, orgId, username, templatePermissionRows, sessionId, isAdmin } = JWTelements
+  const { userId, orgId, username, templatePermissionRows, sessionId, isAdmin, isManager } =
+    JWTelements
 
-  let JWT: any = { ...baseJWT, userId, orgId, username, sessionId, isAdmin }
+  let JWT: any = { ...baseJWT, userId, orgId, username, sessionId, isAdmin, isManager }
   const templateIdsForPolicy: { [policyAbbreviation: string]: number[] } = {}
 
   templatePermissionRows.forEach((permissionRow: PermissionRow) => {

--- a/src/components/postgresConnect.ts
+++ b/src/components/postgresConnect.ts
@@ -978,6 +978,35 @@ class PostgresDB {
     }
   }
 
+  public getUserAdminStatus = async (
+    managementPrefName: string,
+    userId: number,
+    orgId: number | null
+  ) => {
+    const orgMatch = `"organisation_id" ${orgId ? '= $3' : 'IS NULL'}`
+    const text = `
+      SELECT name, user_id, organisation_id, permission_name_id
+      FROM permission_join pj JOIN permission_name pn
+      ON pj.permission_name_id = pn.id
+      WHERE user_id = $2
+      AND ${orgMatch}
+      AND (name = 'admin' OR name = $1)
+      AND is_active = true
+    `
+    const values = [managementPrefName, userId]
+    if (orgId) values.push(orgId)
+    try {
+      const result = await this.query({ text, values })
+      console.log(result.rows)
+      const isAdmin = result.rows.some((row) => row.name === 'admin')
+      const isManager = result.rows.some((row) => row.name === managementPrefName)
+      return { isAdmin, isManager }
+    } catch (err) {
+      console.log(err.message)
+      throw err
+    }
+  }
+
   public getAllGeneratedRowPolicies = async () => {
     const text = `
       SELECT policyname, tablename 

--- a/src/lookup-table/routes.ts
+++ b/src/lookup-table/routes.ts
@@ -1,7 +1,24 @@
-import { FastifyPluginCallback } from 'fastify'
+import { FastifyPluginCallback, FastifyReply } from 'fastify'
 import { ImportCsvController, ImportCsvUpdateController, ExportCsvController } from './controllers'
+import config from '../config'
 
-const lookupTableRoutes: FastifyPluginCallback<{ prefix: string }> = (server, opts, done) => {
+const lookupTableRoutes: FastifyPluginCallback<{ prefix: string }> = (server, _, done) => {
+  server.addHook('preValidation', async (request: any, reply: FastifyReply) => {
+    const { managerCanEditLookupTables = true } = config
+    const { isAdmin = false, isManager = false } = request.auth
+
+    if (managerCanEditLookupTables) {
+      if (!(isAdmin || isManager)) {
+        reply.statusCode = 401
+        return reply.send({ sucess: false, message: 'Unauthorized: not admin or manager' })
+      }
+    }
+
+    if (!managerCanEditLookupTables && !isAdmin) {
+      reply.statusCode = 401
+      return reply.send({ sucess: false, message: 'Unauthorized: not admin' })
+    }
+  })
   server.post('/import', ImportCsvController)
   server.get('/export/:lookupTableId', ExportCsvController)
   server.post('/import/:lookupTableId', ImportCsvUpdateController)

--- a/src/server.ts
+++ b/src/server.ts
@@ -122,7 +122,6 @@ const startServer = async () => {
           }
         })
 
-        server.register(lookupTableRoutes, { prefix: '/lookup-table' })
         server.register(snapshotRoutes, { prefix: '/snapshot' })
         server.get('/updateRowPolicies', routeUpdateRowPolicies)
         server.get('/get-application-data', routeGetApplicationData)
@@ -153,6 +152,8 @@ const startServer = async () => {
     server.get('/check-triggers', routeTriggers)
     server.post('/preview-actions', routePreviewActions)
     server.post('/extend-application', routeExtendApplication)
+    // Lookup tables requires "systemManager" permission
+    server.register(lookupTableRoutes, { prefix: '/lookup-table' })
 
     // File upload endpoint
     server.post('/upload', async function (request: any, reply) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,7 @@ export interface ServerPreferences {
     defaultFromEmail: string
   }
   systemManagerPermissionName?: string
+  managerCanEditLookupTables?: boolean
   previewDocsMinKeepTime?: string
   previewDocsCleanupSchedule?: number[]
   backupSchedule?: number[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -272,6 +272,7 @@ export const serverPrefKeys: (keyof ServerPreferences)[] = [
   'hoursSchedule',
   'SMTPConfig',
   'systemManagerPermissionName',
+  'managerCanEditLookupTables',
   'previewDocsMinKeepTime',
   'previewDocsCleanupSchedule',
   'backupSchedule',


### PR DESCRIPTION
Fix #816 

Requires front-end https://github.com/openmsupply/conforma-web-app/pull/1501

Changes "/lookup-tables" endpoint from being an "admin" route to a normal authenticated route. However, it has an additional check for *either* "admin" or "systemManager" permission.