### PR TITLE
#1539F Multiple trigger protection

### DIFF
--- a/database/buildSchema/43_views_functions_triggers.sql
+++ b/database/buildSchema/43_views_functions_triggers.sql
@@ -112,7 +112,8 @@ CREATE OR REPLACE FUNCTION public.add_event_to_trigger_queue ()
     RETURNS TRIGGER
     AS $trigger_queue$
 BEGIN
-    --
+    -- Prevent triggers being added to queue if another one for the same event
+    -- is already in progress:
     IF (
             SELECT COUNT(*) FROM trigger_queue
             WHERE trigger_type = NEW.trigger::public.trigger

--- a/database/buildSchema/43_views_functions_triggers.sql
+++ b/database/buildSchema/43_views_functions_triggers.sql
@@ -113,6 +113,15 @@ CREATE OR REPLACE FUNCTION public.add_event_to_trigger_queue ()
     AS $trigger_queue$
 BEGIN
     --
+    IF (
+            SELECT COUNT(*) FROM trigger_queue
+            WHERE trigger_type = NEW.trigger::public.trigger
+            AND "table" = TG_TABLE_NAME
+            AND record_id = NEW.id
+            AND (status = 'TRIGGERED' OR status = 'ACTIONS_DISPATCHED')
+        ) > 0 THEN
+        RETURN NULL;
+    END IF;
     IF TG_TABLE_NAME = 'trigger_schedule' OR TG_TABLE_NAME = 'verification' THEN
         INSERT INTO trigger_queue (trigger_type, "table", record_id, event_code, data, timestamp, status)
             VALUES (NEW.trigger::public.trigger, TG_TABLE_NAME, NEW.id, NEW.event_code, NEW.data, CURRENT_TIMESTAMP, 'TRIGGERED');


### PR DESCRIPTION
An additional fix for https://github.com/openmsupply/conforma-web-app/issues/1539

(Front-end PR: https://github.com/openmsupply/conforma-web-app/pull/1540)

This prevents more than one active version of the same trigger being added to the trigger queue. The front-end PR should solve the problem, but this is extra protection in case there are any other ways to cause duplicate triggers (such as setting triggers via direct API calls/Postman).